### PR TITLE
docs: correct stale Vercel deploy claim (self-hosted now)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Rate limits: 20 req/60s for chat, 15 req/60s for professional chat.
 | Embeddings | Transformers.js (all-MiniLM-L6-v2, 384d)                     |
 | Auth       | Supabase Auth + Row Level Security                           |
 | Email      | AWS SES                                                      |
-| Deployment | Vercel, GitHub Actions CI/CD                                 |
+| Deployment | Self-hosted on Hetzner (behind Caddy); GitHub Actions CI     |
 
 ---
 


### PR DESCRIPTION
Fixes the stale `Deployment | Vercel` line in the README stack table — botsmann is self-hosted on Hetzner since the 2026-06-12 exit (b87efa3a).

### ⚠️ Surfaced, NOT auto-fixed (needs a decision)
- **`vercel.json` carries a live daily cron** (`/api/rebuild`, `0 9 * * *`). It was **not** reimplemented in GitHub Actions or systemd during the migration — so the daily rebuild has likely been **silently dead since 2026-06-12**. Deleting `vercel.json` would cement that. **Recommend:** reimplement the cron (GH Actions scheduled workflow or a box systemd timer hitting `/api/rebuild`), then remove `vercel.json` + `scripts/deployment/deploy-monitor.sh`.
- README **`Live` badge** still points at `botsmann.vercel.app` — update to the real live domain once confirmed.
- App-code `VERCEL_URL` references (base-URL detection) are runtime logic — left untouched on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)