### PR TITLE
ci: strict verify gate + verify SSOT script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,19 +20,16 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
-      - name: Install dependencies and build
-        run: npm run build:ci
+      - name: Install dependencies
+        run: npm ci
+
+      # Single SSOT gate: format:check + lint + test + build.
+      # Runs verbatim what developers run locally via `npm run verify`.
+      # No --if-present: a missing/renamed gate script fails loudly.
+      - name: Verify (format + lint + test + build)
+        run: npm run verify
         env:
           NEXT_PUBLIC_DEPLOY_TIME: ${{ github.event.head_commit.timestamp }}
-
-      - name: Run format check
-        run: npm run format:check --if-present
-
-      - name: Run linting
-        run: npm run lint --if-present
-
-      - name: Run tests
-        run: npm run test --if-present
 
       - name: Install Vercel CLI
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# AGENTS.md — Botsmann
+
+Operating guide for automated agents and new contributors. Mirrors key facts from
+`.claude/CLAUDE.md`. Keep this file in sync when the stack or workflow changes.
+
+## Stack
+
+| Layer      | Technology                     |
+| ---------- | ------------------------------ |
+| Framework  | Next.js 14 (App Router)        |
+| Language   | TypeScript (strict)            |
+| Styling    | Tailwind CSS                   |
+| Database   | Supabase (Postgres)            |
+| Testing    | Jest (unit) + Playwright (e2e) |
+| Deployment | Vercel                         |
+
+## Everyday commands
+
+```bash
+npm install        # install deps
+npm run dev        # local dev server, port 3000
+npm run build      # production build (also type-checks)
+npm run test       # Jest unit tests
+npm run test:e2e   # Playwright end-to-end tests
+```
+
+## verify — the single gate (SSOT)
+
+```bash
+npm run verify     # format:check → lint → test → build
+```
+
+`verify` is the one definition of "green". CI runs it verbatim (see
+`.github/workflows/deploy.yml`), so a local green `verify` means a green CI.
+Run it before declaring any change done. The gate uses explicit script names
+(no `--if-present`): a missing or renamed gate script fails loudly instead of
+silently passing.
+
+## Supabase migrations — MANUAL
+
+Migrations live in `supabase/migrations/` (`NNN_description.sql`, sequential).
+They are **applied manually** — CI and the Vercel deploy do **not** run them.
+Never edit an already-applied migration; always add a new numbered file.
+Helper scripts live in `scripts/` (e.g. `run-migration.ts`, `test-db-connection.ts`).
+
+## Deploy path
+
+- Push / merge to `main` → GitHub Actions runs `npm run verify`, then deploys to
+  **Vercel production**.
+- Pull requests → `verify` runs and a Vercel **preview** deploy is created.
+- Prod only receives commits that passed CI (the local `.husky/pre-push` hook is
+  CI-gated for the parallel Hetzner mirror).
+
+## Security
+
+This repo has a history of leaked keys. Never commit real secrets. Only
+`.env.example` holds placeholder values; real values live in Vercel env settings
+and local `.env*` files (git-ignored). Do not print secret values in logs or PRs.
+
+## Conventions
+
+Follow `.claude/CLAUDE.md` and the imported global standards: SSOT, DRY, SoC,
+TypeScript strict, no hardcoded secrets, no `console.log` in production, semantic
+Tailwind classes over inline styles.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint:fix": "next lint --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "verify": "npm run format:check && npm run lint && npm run test && npm run build",
     "prepare": "husky install",
     "lint-staged": "lint-staged"
   },


### PR DESCRIPTION
## What

Closes two DevOps gaps from the prior audit (Grade B):

**(a) Silent-pass gate → strict.** The CI gate used `npm run <script> --if-present`, which silently passes if a gate script is renamed or removed (a false green). Replaced with a single strict `npm run verify` — a missing/renamed gate script now fails loudly.

**(b) No single `verify` SSOT / no docs.** Added a `"verify"` npm script and an `AGENTS.md`.

## Changes

- **`package.json`**: `"verify": "npm run format:check && npm run lint && npm run test && npm run build"` — the one definition of "green".
- **`.github/workflows/deploy.yml`**: replaced `build:ci` + three `--if-present` steps with `npm ci` + `npm run verify` (called verbatim, same env). No behavior change to the Vercel deploy steps.
- **`AGENTS.md`** (new): stack, dev commands, `verify`, manual Supabase migrations, and the Vercel deploy path. Mirrors `.claude/CLAUDE.md`.

## Verification

- `format:check`, `lint`, `test` (227 passed / 2 skipped) all green locally.
- `verify` chain runs each real script in order and correctly **failed loudly** on an unformatted file before I fixed it — confirming strictness.
- `next build` compiles successfully; a full local `verify` can't finish the build's type-check phase only because this sandbox blocks `fonts.googleapis.com`. CI has network and builds green.
- `deploy.yml` YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)