### PR TITLE
fix(ai): replace retired Claude model defaults

### DIFF
--- a/agents/research-agent/src/providers.py
+++ b/agents/research-agent/src/providers.py
@@ -30,7 +30,7 @@ class ProviderConfig:
 
 # Default models per provider
 DEFAULT_MODELS = {
-    Provider.ANTHROPIC: "claude-sonnet-4-20250514",
+    Provider.ANTHROPIC: "claude-sonnet-5",
     Provider.GROQ: "llama-3.1-70b-versatile",
     Provider.OLLAMA: "phi3",  # Small, fast, works on most machines
 }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -55,7 +55,7 @@ export const API_CONFIG = {
 
   // OpenRouter
   OPENROUTER_API_URL: 'https://openrouter.ai/api/v1/chat/completions',
-  OPENROUTER_DEFAULT_MODEL: 'anthropic/claude-3.5-sonnet',
+  OPENROUTER_DEFAULT_MODEL: 'anthropic/claude-sonnet-5',
 
   // Token limits
   MAX_CONTEXT_CHARS: 8000,

--- a/tests/__tests__/lib/llm-client.test.ts
+++ b/tests/__tests__/lib/llm-client.test.ts
@@ -6,7 +6,7 @@ jest.mock('@/lib/constants', () => ({
     GROQ_API_URL: 'https://api.groq.com/openai/v1/chat/completions',
     GROQ_MODEL: 'llama-3.1-8b-instant',
     OPENROUTER_API_URL: 'https://openrouter.ai/api/v1/chat/completions',
-    OPENROUTER_DEFAULT_MODEL: 'anthropic/claude-3.5-sonnet',
+    OPENROUTER_DEFAULT_MODEL: 'anthropic/claude-sonnet-5',
   },
 }));
 
@@ -162,10 +162,10 @@ describe('generateLLMResponse', () => {
       expect(mockFetch).toHaveBeenCalledWith(
         'https://openrouter.ai/api/v1/chat/completions',
         expect.objectContaining({
-          body: expect.stringContaining('"model":"anthropic/claude-3.5-sonnet"'),
+          body: expect.stringContaining('"model":"anthropic/claude-sonnet-5"'),
         }),
       );
-      expect(result.model).toBe('anthropic/claude-3.5-sonnet');
+      expect(result.model).toBe('anthropic/claude-sonnet-5');
     });
 
     it('uses custom model when specified', async () => {


### PR DESCRIPTION
## Summary
- `agents/research-agent/src/providers.py`: Anthropic provider default `claude-sonnet-4-20250514` (deprecated, retires June 2026) → `claude-sonnet-5`. The existing `RESEARCH_MODEL` env override already covers config-driven selection — no new plumbing needed (YAGNI).
- `lib/constants.ts`: `OPENROUTER_DEFAULT_MODEL` `anthropic/claude-3.5-sonnet` (retired Oct 2025 — dead slug) → `anthropic/claude-sonnet-5`, verified against OpenRouter's live `/api/v1/models` list.
- `tests/__tests__/lib/llm-client.test.ts`: fixtures updated to match.

## Verification
`npm run verify` gate green: prettier ✓, eslint (max-warnings 0) ✓, jest 227 passed / 2 skipped ✓, next build ✓. No pre-existing failures encountered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)