### PR TITLE
fix(ci): remove an input the reusable deploy workflow does not accept

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,5 +18,4 @@ jobs:
     uses: maonakamoto/fleetcrown/.github/workflows/selfhost-deploy.yml@main
     with:
       app: botsmann
-      node-version-file: .nvmrc
     secrets: inherit


### PR DESCRIPTION
botsmann's deploy came back as `startup_failure` — GitHub could not start the workflow at all, so there are no logs, just a red X.

Cause: the `.nvmrc` change rewrote every `node-version:` line under `.github/workflows/`, and this shim had one — but there it was an **input to the reusable deploy workflow**, not a `setup-node` argument. Rewriting it to `node-version-file:` created an input the reusable workflow does not declare, which makes the calling workflow invalid.

The shared pipeline reads `.nvmrc` from the repo itself now, so the shim needs no Node input at all. botsmann's `.nvmrc` is already 22, matching its CI.