### PR TITLE
fix(ci): declare the failing-job list before the branch that can skip it

### DIFF
--- a/scripts/ci/auto-merge-sweep.sh
+++ b/scripts/ci/auto-merge-sweep.sh
@@ -66,6 +66,12 @@ base_sha=$(gh api "repos/${REPO}/commits/${BASE_BRANCH}" --jq '.sha')
 base_ci=$(gh run list --repo "$REPO" --workflow "$CI_WORKFLOW" --branch "$BASE_BRANCH" --limit 1 \
   --json databaseId,status,conclusion,headSha --jq '.[0] // empty')
 
+# Declared before the branch that can skip it: `set -u` is on and the merge
+# site below always reads it. A base branch with no CI history takes the
+# "proceeding" path, and an assignment living only in the else-branch made
+# the entire sweep die with "base_red_jobs: unbound variable".
+base_red_jobs=""
+
 if [ -z "$base_ci" ]; then
   echo "[auto-merge] no CI history for ${BASE_BRANCH} — proceeding"
 else
@@ -96,7 +102,6 @@ else
   # post-merge base is better than the pre-merge base. Still refused: a PR that
   # does not cover the failing jobs, one that covers only some of them, and a
   # base failure whose jobs cannot be identified at all.
-  base_red_jobs=""
   if [ "$base_conclusion" != "success" ]; then
     base_run_id=$(printf '%s' "${base_ci}" | jq -r '.databaseId')
     base_red_jobs=$(gh run view "${base_run_id}" --repo "$REPO" --json jobs \


### PR DESCRIPTION
Follow-up to the red-base carve-out: it declared the failing-job list inside
the `else` branch of the "does the base have CI history?" check, but `set -u` is
on and the merge site always reads it.

So on a base branch with **no CI history at all**, the sweep took the
"proceeding" path and died:

    [auto-merge] no CI history for main — proceeding
    auto-merge-sweep.sh: line 249: base_red_jobs: unbound variable
    exit 1

That is auto-merge dead for every PR in the repo, not a degraded path. Latent
here because this base does have CI history — but it is one fresh repo away from
being real, and it was introduced by my own change.

Fixed by declaring it once, before the branch that can skip the assignment.
Covered upstream by a regression test that runs the real script against a `gh`
reporting no CI history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)