### PR TITLE
ci: make the verify job actually run verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,16 @@ jobs:
 
       - run: npm ci
 
-      - name: Format check
-        run: npm run format:check --if-present
-
-      - name: Lint
-        run: npm run lint --if-present
-
-      - name: Test
-        run: npm run test --if-present
-
-      - name: Build
-        run: npm run build
+      # SSOT: format + lint + typecheck + test + build are bundled in the
+      # `verify` npm script (package.json), and CI calls it verbatim so the
+      # gating chain cannot drift from what a developer runs locally. This job
+      # was already NAMED verify but re-inlined the chain, which is how the
+      # typecheck gate went missing: `tsc --noEmit` ran nowhere, and type
+      # errors were caught only as a side effect of `next build`.
+      #
+      # The `--if-present` flags are gone on purpose. They made three of these
+      # gates unable to fail: rename or delete the `lint` script and the step
+      # passes green instead of erroring. A gate that cannot go red is not a
+      # gate — the same defect that let evig ship 25 failing tests under a ✓.
+      - name: Verify (format + lint + typecheck + test + build)
+        run: npm run verify

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "verify": "npm run format:check && npm run lint && npm run test && npm run build",
+    "typecheck": "tsc --noEmit",
+    "verify": "npm run format:check && npm run lint && npm run typecheck && npm run test && npm run build",
     "prepare": "husky install",
     "lint-staged": "lint-staged"
   },


### PR DESCRIPTION
## The bug

This repo's CI job is **named** `verify` and did not call `npm run verify`. It re-inlined the chain by hand, and the hand-written copy had drifted:

| | format | lint | typecheck | test | build |
|---|---|---|---|---|---|
| `package.json` `verify` | ✓ | ✓ | — | ✓ | ✓ |
| `.github/workflows/ci.yml` | ✓ `--if-present` | ✓ `--if-present` | — | ✓ `--if-present` | ✓ |

Neither ran a typecheck. `tsc --noEmit` existed **nowhere** in this repo, so type errors were caught only as a side effect of `next build` — late, slow, and one `typescript.ignoreBuildErrors` away from not being caught at all.

## Two fixes, one principle

**1. A real `typecheck` gate.** Added `"typecheck": "tsc --noEmit"` and put it in `verify` *before* test and build, so it fails in seconds rather than after a full Next build. Verified it is already clean (exit 0) — this closes a hole, it does not paper over a backlog.

**2. CI calls `verify` verbatim, and `--if-present` is gone.** Those flags made three of the four gates unable to fail: rename or delete the `lint` script and the step passes green instead of erroring.

A gate that cannot go red is not a gate. That is the same defect that let evig report "Run Tests ✓" on every PR for three weeks while 25 assertions were failing (evig#306), and the reason dotfiles#14 now sweeps the fleet for discarded gates. This repo had the quieter variant: not a swallowed result, but a hand-copied gate list that silently lost an entry.

## Verification

Full `npm run verify` locally: format → lint → typecheck → test → build, **exit 0**. "Green verify locally ⇒ green CI" is now true here by construction, because they are the same command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
