### PR TITLE
ci: call the verify SSOT instead of hand-copying it with --if-present

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,11 @@ jobs:
 
       - run: npm ci
 
-      - name: Format check
-        run: npm run format:check --if-present
-
-      - name: Lint
-        run: npm run lint --if-present
-
-      - name: Test
-        run: npm run test --if-present
-
-      - name: Build
-        run: npm run build
+      # SSOT: "verified" is defined ONCE, in package.json `verify`
+      # (= format:check + lint + test + build), and run identically here and
+      # locally. This used to hand-copy those four steps, which drifts the
+      # moment `verify` changes — and each carried `--if-present`, so renaming
+      # or deleting a script would have turned its gate into a silent pass. A
+      # gate that cannot go red is worse than no gate, because it is believed.
+      - name: Verify
+        run: npm run verify


### PR DESCRIPTION
CI listed `format:check`, `lint`, `test` and `build` as four separate steps — the same four `npm run verify` already runs — with `--if-present` on each.

That combination is the **gate that cannot go red**. `--if-present` turns a missing script into a **pass**, so renaming or deleting any of those scripts would have left CI green while the check silently stopped running. And a hand-copied list drifts from `verify` the moment `verify` changes — leaving a local gate and a CI gate that are two different things, only one of which blocks a merge.

CI now runs `npm run verify` verbatim: one definition of verified, enforced identically on a laptop and on the branch.

Found by `dotfiles/scripts/ci/check-verify-contract.sh` (maonakamoto/dotfiles#16), which now enforces this contract across the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)