### PR TITLE
fix(ci): point Actions at the bitbaum org, so merges and deploys resume

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,7 +1,7 @@
 # Auto-merge — nobody is in the merge loop.
 #
 # Green, ready PRs merge themselves and deploy themselves. The policy lives in
-# ONE place for the whole fleet — catomean/dotfiles,
+# ONE place for the whole fleet — bitbaum/dotfiles,
 # scripts/ci/auto-merge-sweep.sh — and this file only says "run it, with these
 # settings".
 #
@@ -39,7 +39,7 @@ permissions:
 
 jobs:
   sweep:
-    uses: catomean/dotfiles/.github/workflows/auto-merge-sweep.yml@master
+    uses: bitbaum/dotfiles/.github/workflows/auto-merge-sweep.yml@master
     with:
       base_branch: main
       ci_workflow: ci.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: Deploy
 
 # Push to main → deploy botsmann.orangecat.ch to bitbaum. All the logic lives in
-# one place: catomean/fleetcrown/.github/workflows/selfhost-deploy.yml (docs:
+# one place: bitbaum/fleetcrown/.github/workflows/selfhost-deploy.yml (docs:
 # docs/infrastructure/self-host-cd.md there). It waits for this commit's own CI
 # to go green before anything reaches the box.
 #
@@ -16,7 +16,7 @@ on:
 
 jobs:
   deploy:
-    uses: catomean/fleetcrown/.github/workflows/selfhost-deploy.yml@main
+    uses: bitbaum/fleetcrown/.github/workflows/selfhost-deploy.yml@main
     with:
       app: botsmann
     secrets: inherit


### PR DESCRIPTION
The fleet moved to the `bitbaum` org, and Actions' `uses:` resolver does not follow a repo transfer.

That is the whole bug, and its danger is that every tool available to check it disagrees with the runner. `gh api repos/catomean/dotfiles` returns the repo. `git clone` works. `git push` works. All of them follow the redirect. The `uses:` resolver alone does not — so the reference reads as correct everywhere except the one place it is consumed.

## What it looks like when broken

Not a red check. **Zero jobs**, no logs, and a bare *"This run likely failed because of a workflow file issue."* The workflow that would have reported a failure is the one that could not start.

Downstream, a PR sits at `CLEAN` / `MERGEABLE` with nothing marked wrong. Nothing announces an outage; work just quietly stops moving. In this fleet that had already accumulated **11 clean unmerged dependabot PRs in orangecat and 8 in reparaturbonus-zh** before anyone noticed.

## Why this repo, now

`bitbaum/fleetcrown` hit the same failure and fixed it in #415; this applies the identical change here. Two owners appear across the fleet — `maonakamoto` (never repaired after the user rename) and `catomean` (repaired for the rename, then broken again by the org transfer). Both resolve to `bitbaum` now.

Scope is `.github/workflows/` only — those are the references that actually break a run. Docs naming the old owner are stale but not load-bearing, and rewriting them in bulk across 15 repos would be a large unverifiable diff attached to an outage fix.

## Verification

The honest check is not that CI passes — CI passing is compatible with the sweep still being dead, which is exactly how this went unnoticed. It is that **the auto-merge run produces jobs instead of zero**, which can only be observed after this lands on the default branch. I am watching for that on each repo rather than treating the merge as the finish line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvjGNAS9CMfEGNW26tUR4P
