### PR TITLE
chore(ci): GitHub owner catomean -> bitbaum

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,7 +1,7 @@
 # Auto-merge — nobody is in the merge loop.
 #
 # Green, ready PRs merge themselves and deploy themselves. The policy lives in
-# ONE place for the whole fleet — catomean/dotfiles,
+# ONE place for the whole fleet — bitbaum/dotfiles,
 # scripts/ci/auto-merge-sweep.sh — and this file only says "run it, with these
 # settings".
 #
@@ -39,7 +39,7 @@ permissions:
 
 jobs:
   sweep:
-    uses: catomean/dotfiles/.github/workflows/auto-merge-sweep.yml@master
+    uses: bitbaum/dotfiles/.github/workflows/auto-merge-sweep.yml@master
     with:
       base_branch: main
       ci_workflow: ci.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: Deploy
 
 # Push to main → deploy botsmann.orangecat.ch to bitbaum. All the logic lives in
-# one place: catomean/fleetcrown/.github/workflows/selfhost-deploy.yml (docs:
+# one place: bitbaum/fleetcrown/.github/workflows/selfhost-deploy.yml (docs:
 # docs/infrastructure/self-host-cd.md there). It waits for this commit's own CI
 # to go green before anything reaches the box.
 #
@@ -16,7 +16,7 @@ on:
 
 jobs:
   deploy:
-    uses: catomean/fleetcrown/.github/workflows/selfhost-deploy.yml@main
+    uses: bitbaum/fleetcrown/.github/workflows/selfhost-deploy.yml@main
     with:
       app: botsmann
     secrets: inherit

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.16",
         "@xenova/transformers": "^2.17.2",
-        "ai-kit": "github:catomean/ai-kit#v0.4.0",
+        "ai-kit": "github:bitbaum/ai-kit#v0.4.0",
         "autoprefixer": "^10.4.17",
         "date-fns": "^4.1.0",
         "gray-matter": "^4.0.3",
@@ -5457,7 +5457,7 @@
     },
     "node_modules/ai-kit": {
       "version": "0.4.0",
-      "resolved": "git+ssh://git@github.com/catomean/ai-kit.git#44f6bcaa69350c324b419bfd7026053dac1eb187",
+      "resolved": "git+ssh://git@github.com/bitbaum/ai-kit.git#44f6bcaa69350c324b419bfd7026053dac1eb187",
       "license": "MIT",
       "dependencies": {
         "ai-forms": "^0.1.2"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.16",
     "@xenova/transformers": "^2.17.2",
-    "ai-kit": "github:catomean/ai-kit#v0.4.0",
+    "ai-kit": "github:bitbaum/ai-kit#v0.4.0",
     "autoprefixer": "^10.4.17",
     "date-fns": "^4.1.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Why

`main` cannot deploy. The org was renamed `catomean` → `bitbaum`, but `deploy.yml` and `auto-merge.yml` still reference the old owner, so the reusable-workflow lookup fails before any job starts:

> This run likely failed because of a workflow file issue.

Run [33146975960](https://github.com/bitbaum/botsmann/actions/runs/33146975960) failed this way, blocking the deploy of #139. GitHub's owner redirect covers `git` remotes but **not** `uses:` references to reusable workflows.

## What

Cherry-picked verbatim from the commit already authored locally (`08f1d31e`) — no new authoring:

- `deploy.yml` → `bitbaum/fleetcrown/.github/workflows/selfhost-deploy.yml@main`
- `auto-merge.yml` → same owner swap
- `package.json` / `package-lock.json` repository URL

No `catomean` references remain in `.github/` or `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVwg8DKHQktxJuHeLM3xpG