### PR TITLE
chore(ci): call the auto-merge sweep from bitbaum/fleet

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -39,7 +39,7 @@ permissions:
 
 jobs:
   sweep:
-    uses: bitbaum/dotfiles/.github/workflows/auto-merge-sweep.yml@master
+    uses: bitbaum/fleet/.github/workflows/auto-merge-sweep.yml@main
     with:
       base_branch: main
       ci_workflow: ci.yml


### PR DESCRIPTION
The fleet automation moved out of dotfiles into [bitbaum/fleet](https://github.com/bitbaum/fleet) (2026-08-28); the dotfiles path this repo called is now a forwarding shim. This repoints the `uses:` line at the sweep's real home — one line, identical interface, already proven live through the shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AZCNYHwjEeqxNpYCUk6Yna