### PR TITLE
refactor(design): finish the colour sweep, and make it enforceable

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,13 +4,11 @@ import { professionals } from '@/data/professionals';
 
 export default function About() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-action-tint">
       {/* Hero */}
       <section className="max-w-4xl mx-auto px-6 pt-20 pb-16">
         <h1 className="text-4xl md:text-5xl font-bold mb-6">
-          <span className="bg-gradient-to-r from-gray-900 via-blue-900 to-purple-900 bg-clip-text text-transparent">
-            Expert Advice for Everyone
-          </span>
+          <span className="text-ink">Expert Advice for Everyone</span>
         </h1>
         <p className="text-xl text-gray-600 leading-relaxed max-w-3xl">
           Botsmann brings AI-powered professionals to your fingertips. Get guidance from specialized
@@ -66,7 +64,7 @@ export default function About() {
       {/* Privacy First */}
       <section className="max-w-4xl mx-auto px-6 py-12">
         <h2 className="text-2xl font-bold mb-6 text-gray-900">Privacy First</h2>
-        <div className="bg-gradient-to-br from-blue-50 to-indigo-50 rounded-2xl p-8 border border-blue-100">
+        <div className="bg-action-tint rounded-2xl p-8 border border-edge">
           <p className="text-lg text-gray-700 mb-6">
             Your conversations with our AI professionals are private. We do not use your data to
             train models. We do not share your information with third parties. Your health
@@ -100,7 +98,7 @@ export default function About() {
       {/* The Future: Embodied AI */}
       <section className="max-w-4xl mx-auto px-6 py-12">
         <h2 className="text-2xl font-bold mb-6 text-gray-900">The Future: Embodied AI</h2>
-        <div className="bg-gradient-to-br from-purple-50 to-pink-50 rounded-2xl p-8 border border-purple-100">
+        <div className="bg-action-tint rounded-2xl p-8 border border-edge">
           <p className="text-lg text-gray-700 mb-6">
             We envision a future where AI professionals are not just on your screen but present in
             your world. Imagine a health advisor that monitors your wellbeing through wearables. A
@@ -130,25 +128,25 @@ export default function About() {
           </p>
           <ul className="space-y-3 mb-8">
             <li className="flex items-center gap-3">
-              <span className="text-blue-600">&#10140;</span>
+              <span className="text-action">&#10140;</span>
               <span className="text-gray-700">On-premises deployment options</span>
             </li>
             <li className="flex items-center gap-3">
-              <span className="text-blue-600">&#10140;</span>
+              <span className="text-action">&#10140;</span>
               <span className="text-gray-700">SSO and team management</span>
             </li>
             <li className="flex items-center gap-3">
-              <span className="text-blue-600">&#10140;</span>
+              <span className="text-action">&#10140;</span>
               <span className="text-gray-700">HIPAA and GDPR compliance</span>
             </li>
             <li className="flex items-center gap-3">
-              <span className="text-blue-600">&#10140;</span>
+              <span className="text-action">&#10140;</span>
               <span className="text-gray-700">Custom training on your knowledge base</span>
             </li>
           </ul>
           <Link
             href="/enterprise"
-            className="inline-flex items-center gap-2 bg-blue-600 text-white px-6 py-3 rounded-xl font-semibold hover:bg-blue-700 transition-colors"
+            className="inline-flex items-center gap-2 bg-action text-white px-6 py-3 rounded-xl font-semibold hover:bg-action-hover transition-colors"
           >
             Learn About Enterprise
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -165,7 +163,7 @@ export default function About() {
 
       {/* CTA */}
       <section className="max-w-4xl mx-auto px-6 py-16">
-        <div className="bg-gradient-to-r from-blue-600 to-purple-600 rounded-2xl p-8 md:p-12 text-white text-center">
+        <div className="bg-action rounded-2xl p-8 md:p-12 text-white text-center">
           <h2 className="text-2xl md:text-3xl font-bold mb-4">
             Ready to Meet Your AI Professional?
           </h2>

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -154,7 +154,7 @@ function AuthCallbackContent() {
           <div className="space-y-3">
             <Link
               href={ROUTES.AUTH.SIGNIN}
-              className="block w-full py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition-colors text-center"
+              className="block w-full py-3 bg-action text-white rounded-lg font-medium hover:bg-action-hover transition-colors text-center"
             >
               Go to Sign In
             </Link>
@@ -200,7 +200,7 @@ function LoadingFallback() {
  */
 export default function AuthCallbackPage() {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white flex items-center justify-center px-4">
+    <div className="min-h-screen bg-gradient-to-b from-action-tint to-white flex items-center justify-center px-4">
       <div className="max-w-md w-full">
         <div className="text-center mb-8">
           <Link href="/" className="text-3xl font-bold text-gray-900">

--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -85,7 +85,7 @@ export default function ForgotPasswordPage() {
   const isRateLimited = rateLimitSeconds > 0;
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white flex items-center justify-center px-4">
+    <div className="min-h-screen bg-gradient-to-b from-action-tint to-white flex items-center justify-center px-4">
       <div className="max-w-md w-full">
         <div className="text-center mb-8">
           <Link href="/" className="text-3xl font-bold text-gray-900">
@@ -106,7 +106,7 @@ export default function ForgotPasswordPage() {
               <p className="text-sm text-gray-500 mb-6">
                 Didn&apos;t receive the email? Check your spam folder or try again.
               </p>
-              <Link href={ROUTES.AUTH.SIGNIN} className="text-blue-600 hover:underline">
+              <Link href={ROUTES.AUTH.SIGNIN} className="text-action hover:underline">
                 Back to Sign In
               </Link>
             </div>
@@ -154,7 +154,7 @@ export default function ForgotPasswordPage() {
                   onChange={(e) => setEmail(e.target.value)}
                   required
                   disabled={isRateLimited}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-50 disabled:text-gray-500"
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-action disabled:bg-gray-50 disabled:text-gray-500"
                   placeholder="you@example.com"
                 />
               </div>
@@ -162,7 +162,7 @@ export default function ForgotPasswordPage() {
               <button
                 type="submit"
                 disabled={loading || isRateLimited}
-                className="w-full py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                className="w-full py-3 bg-action text-white rounded-lg font-medium hover:bg-action-hover disabled:opacity-50 transition-colors"
               >
                 {loading
                   ? 'Sending...'
@@ -176,7 +176,7 @@ export default function ForgotPasswordPage() {
           {!success && (
             <div className="mt-6 text-center text-sm text-gray-600">
               Remember your password?{' '}
-              <Link href={ROUTES.AUTH.SIGNIN} className="text-blue-600 hover:underline">
+              <Link href={ROUTES.AUTH.SIGNIN} className="text-action hover:underline">
                 Sign in
               </Link>
             </div>

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -66,7 +66,7 @@ export default function ResetPasswordPage() {
   // Invalid or expired link
   if (!isValidSession) {
     return (
-      <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white flex items-center justify-center px-4">
+      <div className="min-h-screen bg-gradient-to-b from-action-tint to-white flex items-center justify-center px-4">
         <div className="max-w-md w-full">
           <div className="text-center mb-8">
             <Link href="/" className="text-3xl font-bold text-gray-900">
@@ -83,7 +83,7 @@ export default function ResetPasswordPage() {
               </p>
               <Link
                 href={ROUTES.AUTH.FORGOT_PASSWORD}
-                className="inline-block px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition-colors"
+                className="inline-block px-6 py-3 bg-action text-white rounded-lg font-medium hover:bg-action-hover transition-colors"
               >
                 Request New Link
               </Link>
@@ -101,7 +101,7 @@ export default function ResetPasswordPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white flex items-center justify-center px-4">
+    <div className="min-h-screen bg-gradient-to-b from-action-tint to-white flex items-center justify-center px-4">
       <div className="max-w-md w-full">
         <div className="text-center mb-8">
           <Link href="/" className="text-3xl font-bold text-gray-900">
@@ -121,7 +121,7 @@ export default function ResetPasswordPage() {
               </p>
               <Link
                 href={ROUTES.AUTH.SIGNIN}
-                className="inline-block px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition-colors"
+                className="inline-block px-6 py-3 bg-action text-white rounded-lg font-medium hover:bg-action-hover transition-colors"
               >
                 Sign In
               </Link>
@@ -143,7 +143,7 @@ export default function ResetPasswordPage() {
                   onChange={(e) => setPassword(e.target.value)}
                   required
                   minLength={PASSWORD_MIN_LENGTH}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-action"
                   placeholder={`At least ${PASSWORD_MIN_LENGTH} characters`}
                 />
               </div>
@@ -162,7 +162,7 @@ export default function ResetPasswordPage() {
                   onChange={(e) => setConfirmPassword(e.target.value)}
                   required
                   minLength={PASSWORD_MIN_LENGTH}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-action"
                   placeholder="Confirm your new password"
                 />
               </div>
@@ -170,7 +170,7 @@ export default function ResetPasswordPage() {
               <button
                 type="submit"
                 disabled={loading}
-                className="w-full py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                className="w-full py-3 bg-action text-white rounded-lg font-medium hover:bg-action-hover disabled:opacity-50 transition-colors"
               >
                 {loading ? 'Updating...' : 'Update Password'}
               </button>

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -85,7 +85,7 @@ export default function SignInPage() {
   const isRateLimited = rateLimitSeconds > 0;
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white flex items-center justify-center px-4">
+    <div className="min-h-screen bg-gradient-to-b from-action-tint to-white flex items-center justify-center px-4">
       <div className="max-w-md w-full">
         <div className="text-center mb-8">
           <Link href="/" className="text-3xl font-bold text-gray-900">
@@ -122,7 +122,7 @@ export default function SignInPage() {
                 onChange={(e) => setEmail(e.target.value)}
                 required
                 disabled={isRateLimited}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-50 disabled:text-gray-500"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-action disabled:bg-gray-50 disabled:text-gray-500"
                 placeholder="you@example.com"
               />
             </div>
@@ -134,7 +134,7 @@ export default function SignInPage() {
                 </label>
                 <Link
                   href={ROUTES.AUTH.FORGOT_PASSWORD}
-                  className="text-sm text-blue-600 hover:underline"
+                  className="text-sm text-action hover:underline"
                 >
                   Forgot password?
                 </Link>
@@ -147,7 +147,7 @@ export default function SignInPage() {
                 required
                 disabled={isRateLimited}
                 minLength={6}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-50 disabled:text-gray-500"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-action disabled:bg-gray-50 disabled:text-gray-500"
                 placeholder="Enter your password"
               />
             </div>
@@ -155,7 +155,7 @@ export default function SignInPage() {
             <button
               type="submit"
               disabled={loading || isRateLimited}
-              className="w-full py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+              className="w-full py-3 bg-action text-white rounded-lg font-medium hover:bg-action-hover disabled:opacity-50 transition-colors"
             >
               {loading ? 'Signing in...' : isRateLimited ? `Wait ${rateLimitSeconds}s` : 'Sign In'}
             </button>
@@ -163,7 +163,7 @@ export default function SignInPage() {
 
           <div className="mt-6 text-center text-sm text-gray-600">
             Don&apos;t have an account?{' '}
-            <Link href={ROUTES.AUTH.SIGNUP} className="text-blue-600 hover:underline">
+            <Link href={ROUTES.AUTH.SIGNUP} className="text-action hover:underline">
               Sign up
             </Link>
           </div>

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -87,7 +87,7 @@ export default function SignUpPage() {
   const isRateLimited = rateLimitSeconds > 0;
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white flex items-center justify-center px-4">
+    <div className="min-h-screen bg-gradient-to-b from-action-tint to-white flex items-center justify-center px-4">
       <div className="max-w-md w-full">
         <div className="text-center mb-8">
           <Link href="/" className="text-3xl font-bold text-gray-900">
@@ -105,7 +105,7 @@ export default function SignUpPage() {
                 We sent a confirmation link to <strong>{email}</strong>. Click the link to activate
                 your account.
               </p>
-              <Link href={ROUTES.AUTH.SIGNIN} className="text-blue-600 hover:underline">
+              <Link href={ROUTES.AUTH.SIGNIN} className="text-action hover:underline">
                 Back to Sign In
               </Link>
             </div>
@@ -149,7 +149,7 @@ export default function SignUpPage() {
                   onChange={(e) => setEmail(e.target.value)}
                   required
                   disabled={isRateLimited}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-50 disabled:text-gray-500"
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-action disabled:bg-gray-50 disabled:text-gray-500"
                   placeholder="you@example.com"
                 />
               </div>
@@ -166,7 +166,7 @@ export default function SignUpPage() {
                   required
                   disabled={isRateLimited}
                   minLength={PASSWORD_MIN_LENGTH}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-50 disabled:text-gray-500"
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-action disabled:bg-gray-50 disabled:text-gray-500"
                   placeholder={`At least ${PASSWORD_MIN_LENGTH} characters`}
                 />
               </div>
@@ -186,7 +186,7 @@ export default function SignUpPage() {
                   required
                   disabled={isRateLimited}
                   minLength={PASSWORD_MIN_LENGTH}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-50 disabled:text-gray-500"
+                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-action disabled:bg-gray-50 disabled:text-gray-500"
                   placeholder="Confirm your password"
                 />
               </div>
@@ -194,7 +194,7 @@ export default function SignUpPage() {
               <button
                 type="submit"
                 disabled={loading || isRateLimited}
-                className="w-full py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                className="w-full py-3 bg-action text-white rounded-lg font-medium hover:bg-action-hover disabled:opacity-50 transition-colors"
               >
                 {loading
                   ? 'Creating account...'
@@ -208,7 +208,7 @@ export default function SignUpPage() {
           {!success && (
             <div className="mt-6 text-center text-sm text-gray-600">
               Already have an account?{' '}
-              <Link href={ROUTES.AUTH.SIGNIN} className="text-blue-600 hover:underline">
+              <Link href={ROUTES.AUTH.SIGNIN} className="text-action hover:underline">
                 Sign in
               </Link>
             </div>

--- a/app/auth/verify-email/page.tsx
+++ b/app/auth/verify-email/page.tsx
@@ -97,7 +97,7 @@ export default function VerifyEmailPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white flex items-center justify-center px-4">
+    <div className="min-h-screen bg-gradient-to-b from-action-tint to-white flex items-center justify-center px-4">
       <div className="max-w-md w-full">
         <div className="text-center mb-8">
           <Link href="/" className="text-3xl font-bold text-gray-900">
@@ -108,9 +108,9 @@ export default function VerifyEmailPage() {
         <div className="bg-white rounded-xl shadow-lg border border-gray-200 p-8">
           <div className="text-center">
             {/* Email Icon */}
-            <div className="mx-auto w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mb-6">
+            <div className="mx-auto w-16 h-16 bg-action-tint rounded-full flex items-center justify-center mb-6">
               <svg
-                className="w-8 h-8 text-blue-600"
+                className="w-8 h-8 text-action"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"
@@ -170,7 +170,7 @@ export default function VerifyEmailPage() {
             <button
               onClick={handleResend}
               disabled={sending || sent || isRateLimited}
-              className="w-full py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors mb-4"
+              className="w-full py-3 bg-action text-white rounded-lg font-medium hover:bg-action-hover disabled:opacity-50 transition-colors mb-4"
             >
               {sending
                 ? 'Sending...'
@@ -201,7 +201,7 @@ export default function VerifyEmailPage() {
           <div className="space-y-3">
             <Link
               href={ROUTES.SETTINGS}
-              className="block w-full py-2 text-center text-sm text-gray-600 hover:text-blue-600 transition-colors"
+              className="block w-full py-2 text-center text-sm text-gray-600 hover:text-action transition-colors"
             >
               Continue without verifying (limited features)
             </Link>

--- a/app/bots/BotNavigation.tsx
+++ b/app/bots/BotNavigation.tsx
@@ -179,11 +179,9 @@ export const BotNavigation: React.FC<BotNavigationProps> = ({
                   <Dialog.Panel className="pointer-events-auto w-screen max-w-md">
                     <div className="flex h-full flex-col overflow-y-scroll bg-surface shadow-xl">
                       {/* Header with Botsmann branding */}
-                      <div className="flex items-center justify-between px-4 py-6 border-b border-edge bg-gradient-to-r from-blue-50 to-purple-50">
+                      <div className="flex items-center justify-between px-4 py-6 border-b border-edge bg-action-tint">
                         <div className="flex items-center gap-3">
-                          <div className="flex items-center justify-center w-9 h-9 bg-gradient-to-r from-blue-600 to-purple-600 text-white font-bold text-sm rounded-lg">
-                            B
-                          </div>
+                          <Logo href={null} showText={false} size="sm" />
                           <Dialog.Title className="text-lg font-semibold text-ink">
                             Botsmann
                           </Dialog.Title>

--- a/app/bots/page.tsx
+++ b/app/bots/page.tsx
@@ -9,7 +9,7 @@ export default function BotsList() {
   const readyBots = bots.filter((b) => b.tryLink).map((b) => b.slug);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50">
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-action-tint">
       <div className="mx-auto max-w-screen-xl px-6 py-16">
         {/* Header with Core Concept */}
         <div className="text-center mb-16">
@@ -23,7 +23,7 @@ export default function BotsList() {
           <div className="max-w-4xl mx-auto bg-white rounded-2xl p-8 shadow-lg border border-gray-200">
             <div className="grid md:grid-cols-3 gap-6 items-center">
               <div className="text-center">
-                <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-3">
+                <div className="w-16 h-16 bg-action-tint rounded-full flex items-center justify-center mx-auto mb-3">
                   <span className="text-2xl">📥</span>
                 </div>
                 <h3 className="font-semibold text-gray-900 mb-2">1. Ingest Data</h3>
@@ -33,7 +33,7 @@ export default function BotsList() {
               </div>
 
               <div className="text-center">
-                <div className="w-16 h-16 bg-purple-100 rounded-full flex items-center justify-center mx-auto mb-3">
+                <div className="w-16 h-16 bg-action-tint rounded-full flex items-center justify-center mx-auto mb-3">
                   <span className="text-2xl">🤖</span>
                 </div>
                 <h3 className="font-semibold text-gray-900 mb-2">2. AI Processing</h3>
@@ -83,7 +83,7 @@ export default function BotsList() {
               <Link
                 key={bot.slug}
                 href={getChatPathFromBotSlug(bot.slug)}
-                className="group relative bg-white rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 overflow-hidden border-2 border-gray-100 hover:border-blue-200"
+                className="group relative bg-white rounded-2xl shadow-lg hover:shadow-2xl transition-all duration-300 overflow-hidden border-2 border-gray-100 hover:border-action"
               >
                 {!isReady && (
                   <span className="absolute right-4 top-4 z-10 inline-block bg-gray-900 text-white text-xs font-semibold px-3 py-1 rounded-full">
@@ -115,7 +115,7 @@ export default function BotsList() {
 
                 {/* Data Flow */}
                 <div className="px-6 pb-4">
-                  <div className="bg-gradient-to-r from-blue-50 to-purple-50 rounded-lg p-3">
+                  <div className="bg-action-tint rounded-lg p-3">
                     <div className="grid grid-cols-2 gap-3 text-xs">
                       <div>
                         <div className="font-semibold text-gray-700 mb-1">📥 Input</div>
@@ -150,7 +150,7 @@ export default function BotsList() {
 
                 {/* CTA */}
                 <div className="px-6 pb-6">
-                  <div className="flex items-center text-blue-600 font-semibold group-hover:gap-2 transition-all">
+                  <div className="flex items-center text-action font-semibold group-hover:gap-2 transition-all">
                     <span>Chat Now</span>
                     <svg
                       className="w-5 h-5 transform group-hover:translate-x-1 transition-transform"
@@ -183,7 +183,7 @@ export default function BotsList() {
           </p>
           <Link
             href="/#collaboration"
-            className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-blue-600 to-cyan-600 hover:from-blue-700 hover:to-cyan-700 text-white font-semibold rounded-lg transition-all shadow-md"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-action hover:bg-action-hover text-white font-semibold rounded-lg transition-all shadow-md"
           >
             Let's Build Together
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -60,11 +60,11 @@ export default function CreatePage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-purple-50">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-action-tint">
       {/* Background Effects */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute -top-40 -right-40 w-80 h-80 bg-gradient-to-br from-purple-400 to-pink-600 rounded-full opacity-10 blur-3xl" />
-        <div className="absolute -bottom-40 -left-40 w-96 h-96 bg-gradient-to-tr from-blue-400 to-cyan-600 rounded-full opacity-10 blur-3xl" />
+        <div className="absolute -top-40 -right-40 w-80 h-80 bg-gradient-to-br from-action to-action-hover rounded-full opacity-10 blur-3xl" />
+        <div className="absolute -bottom-40 -left-40 w-96 h-96 bg-gradient-to-tr from-action to-action-hover rounded-full opacity-10 blur-3xl" />
       </div>
 
       <main className="relative max-w-screen-xl mx-auto px-6 py-12">
@@ -106,11 +106,11 @@ export default function CreatePage() {
         {/* Progress Indicator */}
         <div className="flex items-center justify-center gap-4 mb-12">
           <div
-            className={`flex items-center gap-2 ${step === 'pick' ? 'text-purple-600' : 'text-gray-400'}`}
+            className={`flex items-center gap-2 ${step === 'pick' ? 'text-action' : 'text-gray-400'}`}
           >
             <div
               className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold ${
-                step === 'pick' ? 'bg-purple-600 text-white' : 'bg-gray-200 text-gray-500'
+                step === 'pick' ? 'bg-action text-white' : 'bg-gray-200 text-gray-500'
               }`}
             >
               1
@@ -118,17 +118,17 @@ export default function CreatePage() {
             <span className="hidden sm:inline font-medium">Choose</span>
           </div>
 
-          <div className={`w-12 h-0.5 ${step !== 'pick' ? 'bg-purple-600' : 'bg-gray-200'}`} />
+          <div className={`w-12 h-0.5 ${step !== 'pick' ? 'bg-action' : 'bg-gray-200'}`} />
 
           <div
-            className={`flex items-center gap-2 ${step === 'name' ? 'text-purple-600' : 'text-gray-400'}`}
+            className={`flex items-center gap-2 ${step === 'name' ? 'text-action' : 'text-gray-400'}`}
           >
             <div
               className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold ${
                 step === 'name'
-                  ? 'bg-purple-600 text-white'
+                  ? 'bg-action text-white'
                   : step === 'chat'
-                    ? 'bg-purple-600 text-white'
+                    ? 'bg-action text-white'
                     : 'bg-gray-200 text-gray-500'
               }`}
             >
@@ -137,14 +137,14 @@ export default function CreatePage() {
             <span className="hidden sm:inline font-medium">Name</span>
           </div>
 
-          <div className={`w-12 h-0.5 ${step === 'chat' ? 'bg-purple-600' : 'bg-gray-200'}`} />
+          <div className={`w-12 h-0.5 ${step === 'chat' ? 'bg-action' : 'bg-gray-200'}`} />
 
           <div
-            className={`flex items-center gap-2 ${step === 'chat' ? 'text-purple-600' : 'text-gray-400'}`}
+            className={`flex items-center gap-2 ${step === 'chat' ? 'text-action' : 'text-gray-400'}`}
           >
             <div
               className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold ${
-                step === 'chat' ? 'bg-purple-600 text-white' : 'bg-gray-200 text-gray-500'
+                step === 'chat' ? 'bg-action text-white' : 'bg-gray-200 text-gray-500'
               }`}
             >
               3

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -21,7 +21,7 @@ export default function DashboardPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white">
+    <div className="min-h-screen bg-gradient-to-b from-action-tint to-white">
       <div className="max-w-6xl mx-auto px-4 py-8">
         <WelcomeHeader
           user={user}

--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -104,7 +104,7 @@ const DemoPage: FC = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white">
+    <div className="min-h-screen bg-gradient-to-b from-action-tint to-white">
       {/* Header */}
       <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
         <div className="max-w-4xl mx-auto px-4 py-4 flex items-center justify-between">
@@ -125,9 +125,9 @@ const DemoPage: FC = () => {
       </header>
 
       {/* Info Banner */}
-      <div className="bg-blue-100 border-b border-blue-200">
+      <div className="bg-action-tint border-b border-edge">
         <div className="max-w-4xl mx-auto px-4 py-3">
-          <p className="text-sm text-blue-800">
+          <p className="text-sm text-action">
             <strong>How it works:</strong> This assistant uses RAG (Retrieval Augmented Generation)
             to search our knowledge base and generate helpful responses.
             {llmEnabled === true && " Powered by Groq's free LLM tier."}
@@ -148,7 +148,7 @@ const DemoPage: FC = () => {
               >
                 <div
                   className={`max-w-[80%] rounded-2xl px-4 py-3 ${
-                    message.role === 'user' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-900'
+                    message.role === 'user' ? 'bg-action text-white' : 'bg-gray-100 text-gray-900'
                   }`}
                 >
                   <p className="whitespace-pre-wrap">{message.content}</p>
@@ -210,13 +210,13 @@ const DemoPage: FC = () => {
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 placeholder="Ask about Botsmann..."
-                className="flex-1 px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className="flex-1 px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-action focus:border-transparent"
                 disabled={isLoading}
               />
               <button
                 type="submit"
                 disabled={isLoading || !input.trim()}
-                className="px-6 py-3 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                className="px-6 py-3 bg-action text-white rounded-xl font-medium hover:bg-action-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
                 Send
               </button>
@@ -266,7 +266,7 @@ const DemoPage: FC = () => {
               <strong>Want this for your business?</strong> This is a simplified demo. For
               production, we use vector embeddings for semantic search, and can deploy locally on
               your infrastructure for maximum privacy.{' '}
-              <Link href="/contact" className="text-blue-600 hover:underline">
+              <Link href="/contact" className="text-action hover:underline">
                 Book a consultation →
               </Link>
             </p>

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -67,7 +67,7 @@ export default function DocumentsPage() {
 
   if (!user) {
     return (
-      <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white flex items-center justify-center">
+      <div className="min-h-screen bg-gradient-to-b from-action-tint to-white flex items-center justify-center">
         <div className="max-w-md mx-auto text-center px-6">
           <h1 className="text-2xl font-bold text-gray-900 mb-4">Sign in required</h1>
           <p className="text-gray-600 mb-6">
@@ -76,7 +76,7 @@ export default function DocumentsPage() {
           <div className="space-y-3">
             <Link
               href="/auth/signin"
-              className="block w-full py-3 px-4 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition-colors"
+              className="block w-full py-3 px-4 bg-action text-white rounded-lg font-medium hover:bg-action-hover transition-colors"
             >
               Sign In
             </Link>
@@ -98,7 +98,7 @@ export default function DocumentsPage() {
   const hasReadyDocuments = documents.some((d) => d.status === DOCUMENT_STATUS.READY);
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white">
+    <div className="min-h-screen bg-gradient-to-b from-action-tint to-white">
       <div className="max-w-6xl mx-auto px-4 py-8">
         {/* Page Header with User Controls */}
         <div className="flex items-center justify-between mb-6">
@@ -144,16 +144,16 @@ export default function DocumentsPage() {
         </div>
 
         {/* Info Box */}
-        <div className="mt-8 bg-blue-50 rounded-xl p-6 border border-blue-100">
-          <h3 className="font-semibold text-blue-900 mb-2">How it works</h3>
-          <ol className="list-decimal list-inside space-y-2 text-blue-800">
+        <div className="mt-8 bg-action-tint rounded-xl p-6 border border-edge">
+          <h3 className="font-semibold text-action mb-2">How it works</h3>
+          <ol className="list-decimal list-inside space-y-2 text-action">
             <li>Upload a document (PDF, TXT, or Markdown)</li>
             <li>Click &quot;Process&quot; to extract and index the content</li>
             <li>
               Ask questions in the chat - the AI will search your documents and provide answers
             </li>
           </ol>
-          <p className="mt-4 text-sm text-blue-600">
+          <p className="mt-4 text-sm text-action">
             Your documents are private and only accessible to you. Processing happens locally using
             free AI models. Your conversations are saved automatically.
           </p>

--- a/app/enterprise/page.tsx
+++ b/app/enterprise/page.tsx
@@ -146,29 +146,25 @@ export default function EnterprisePage() {
   ];
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-action-tint">
       {/* Background Effects */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute -top-40 -right-40 w-80 h-80 bg-gradient-to-br from-blue-400 to-purple-600 rounded-full opacity-10 blur-3xl" />
-        <div className="absolute -bottom-40 -left-40 w-96 h-96 bg-gradient-to-tr from-cyan-400 to-blue-600 rounded-full opacity-10 blur-3xl" />
+        <div className="absolute -top-40 -right-40 w-80 h-80 bg-action rounded-full opacity-10 blur-3xl" />
+        <div className="absolute -bottom-40 -left-40 w-96 h-96 bg-gradient-to-tr from-action to-action-hover rounded-full opacity-10 blur-3xl" />
       </div>
 
       <main className="relative max-w-screen-xl mx-auto px-6 py-20">
         {/* Hero */}
         <section className="text-center mb-20 pt-8">
-          <div className="inline-flex items-center gap-2 bg-purple-100 text-purple-800 px-4 py-2 rounded-full text-sm font-medium mb-8">
-            <span className="w-2 h-2 bg-purple-500 rounded-full" />
+          <div className="inline-flex items-center gap-2 bg-action-tint text-action px-4 py-2 rounded-full text-sm font-medium mb-8">
+            <span className="w-2 h-2 bg-action rounded-full" />
             <span>Enterprise-Grade AI Professionals</span>
           </div>
 
           <h1 className="text-4xl md:text-6xl font-bold mb-8 leading-tight">
-            <span className="bg-gradient-to-r from-gray-900 via-blue-900 to-purple-900 bg-clip-text text-transparent">
-              AI Professionals for
-            </span>
+            <span className="text-ink">AI Professionals for</span>
             <br />
-            <span className="bg-gradient-to-r from-blue-600 via-purple-600 to-cyan-600 bg-clip-text text-transparent">
-              Your Organization
-            </span>
+            <span className="text-action">Your Organization</span>
           </h1>
 
           <p className="text-xl text-gray-600 mb-12 max-w-3xl mx-auto leading-relaxed">
@@ -179,7 +175,7 @@ export default function EnterprisePage() {
           <div className="flex flex-col sm:flex-row justify-center gap-4">
             <a
               href="#contact"
-              className="group bg-gradient-to-r from-blue-600 to-purple-600 text-white px-8 py-4 rounded-xl text-lg font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105 transition-all duration-300"
+              className="group bg-action text-white px-8 py-4 rounded-xl text-lg font-semibold shadow-xl hover:shadow-2xl transform hover:scale-105 transition-all duration-300"
             >
               <span className="flex items-center justify-center gap-2">
                 Schedule a Demo
@@ -200,7 +196,7 @@ export default function EnterprisePage() {
             </a>
             <Link
               href="/professionals"
-              className="group border-2 border-gray-300 hover:border-blue-400 px-8 py-4 rounded-xl text-lg font-semibold text-gray-700 hover:text-blue-600 transition-all duration-300"
+              className="group border-2 border-gray-300 hover:border-action px-8 py-4 rounded-xl text-lg font-semibold text-gray-700 hover:text-action transition-all duration-300"
             >
               <span className="flex items-center justify-center gap-2">
                 Try Our Professionals
@@ -226,9 +222,7 @@ export default function EnterprisePage() {
         <section className="mb-20">
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold mb-4">
-              <span className="bg-gradient-to-r from-gray-900 to-gray-600 bg-clip-text text-transparent">
-                Built for Your Industry
-              </span>
+              <span className="text-ink">Built for Your Industry</span>
             </h2>
             <p className="text-gray-600 max-w-2xl mx-auto">
               AI professionals tailored to the specific needs of your organization
@@ -263,9 +257,7 @@ export default function EnterprisePage() {
         <section className="mb-20">
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold mb-4">
-              <span className="bg-gradient-to-r from-gray-900 to-gray-600 bg-clip-text text-transparent">
-                Enterprise Features
-              </span>
+              <span className="text-ink">Enterprise Features</span>
             </h2>
             <p className="text-gray-600 max-w-2xl mx-auto">
               Everything you need to deploy AI professionals at scale
@@ -278,7 +270,7 @@ export default function EnterprisePage() {
                 key={feature.title}
                 className="bg-white rounded-xl p-6 shadow-md border border-gray-100"
               >
-                <div className="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center mb-4 text-blue-600">
+                <div className="w-12 h-12 bg-action-tint rounded-xl flex items-center justify-center mb-4 text-action">
                   {feature.icon}
                 </div>
                 <h3 className="font-bold text-gray-900 mb-2">{feature.title}</h3>
@@ -320,9 +312,7 @@ export default function EnterprisePage() {
         <section id="contact" className="scroll-mt-24">
           <div className="text-center mb-10">
             <h2 className="text-3xl font-bold mb-4">
-              <span className="bg-gradient-to-r from-gray-900 to-gray-600 bg-clip-text text-transparent">
-                Get in Touch
-              </span>
+              <span className="text-ink">Get in Touch</span>
             </h2>
             <p className="text-gray-600">
               Schedule a demo or discuss your specific requirements with our team

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -56,7 +56,7 @@ export default function GlobalError({
             <div className="flex flex-col sm:flex-row gap-3 justify-center">
               <button
                 onClick={reset}
-                className="px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors"
+                className="px-6 py-3 bg-action text-white font-medium rounded-lg hover:bg-action-hover transition-colors"
               >
                 Try again
               </button>
@@ -70,7 +70,7 @@ export default function GlobalError({
 
             <p className="mt-8 text-sm text-gray-500">
               If this problem persists, please{' '}
-              <a href="/contact" className="text-blue-600 hover:underline">
+              <a href="/contact" className="text-action hover:underline">
                 contact support
               </a>
             </p>

--- a/app/infrastructure/page.tsx
+++ b/app/infrastructure/page.tsx
@@ -177,7 +177,7 @@ export default function InfrastructurePage() {
   const selectedProviderData = getProviderById(selectedProvider);
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white">
+    <div className="min-h-screen bg-gradient-to-b from-action-tint to-white">
       <div className="max-w-4xl mx-auto px-4 py-8">
         {/* Page Header */}
         <div className="mb-8">
@@ -308,7 +308,7 @@ export default function InfrastructurePage() {
             <button
               type="submit"
               disabled={saving}
-              className="px-6 py-3 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+              className="px-6 py-3 bg-action text-white rounded-xl font-medium hover:bg-action-hover disabled:opacity-50 transition-colors"
             >
               {saving ? 'Saving...' : 'Save Changes'}
             </button>

--- a/app/knowledge/guides/[slug]/page.tsx
+++ b/app/knowledge/guides/[slug]/page.tsx
@@ -73,7 +73,7 @@ const mdxComponents = {
         : '';
     return (
       <h2 id={id} className="text-2xl font-bold text-gray-900 mt-8 mb-4 scroll-mt-24" {...props}>
-        <a href={`#${id}`} className="hover:text-blue-600 transition-colors">
+        <a href={`#${id}`} className="hover:text-action transition-colors">
           {children}
         </a>
       </h2>
@@ -89,7 +89,7 @@ const mdxComponents = {
         : '';
     return (
       <h3 id={id} className="text-xl font-semibold text-gray-900 mt-6 mb-3 scroll-mt-24" {...props}>
-        <a href={`#${id}`} className="hover:text-blue-600 transition-colors">
+        <a href={`#${id}`} className="hover:text-action transition-colors">
           {children}
         </a>
       </h3>
@@ -118,7 +118,7 @@ const mdxComponents = {
   a: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
     <a
       href={href}
-      className="text-blue-600 hover:text-blue-800 underline transition-colors"
+      className="text-action hover:text-action underline transition-colors"
       target={href?.startsWith('http') ? '_blank' : undefined}
       rel={href?.startsWith('http') ? 'noopener noreferrer' : undefined}
       {...props}
@@ -128,7 +128,7 @@ const mdxComponents = {
   ),
   blockquote: ({ children, ...props }: React.HTMLAttributes<HTMLQuoteElement>) => (
     <blockquote
-      className="border-l-4 border-blue-500 pl-4 py-2 my-4 bg-blue-50 rounded-r-lg italic text-gray-700"
+      className="border-l-4 border-edge pl-4 py-2 my-4 bg-action-tint rounded-r-lg italic text-gray-700"
       {...props}
     >
       {children}
@@ -217,21 +217,21 @@ export default async function GuidePage({ params }: GuidePageProps) {
   return (
     <div className="min-h-screen bg-gradient-to-b from-gray-50 to-white">
       {/* Hero Section */}
-      <div className="bg-gradient-to-r from-blue-50 to-indigo-50 border-b border-blue-100">
+      <div className="bg-action-tint border-b border-edge">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
           {/* Breadcrumb */}
           <nav className="flex items-center gap-2 text-sm text-gray-500 mb-6">
-            <Link href="/knowledge" className="hover:text-blue-600">
+            <Link href="/knowledge" className="hover:text-action">
               Knowledge
             </Link>
             <span>/</span>
-            <Link href="/knowledge/guides" className="hover:text-blue-600">
+            <Link href="/knowledge/guides" className="hover:text-action">
               Guides
             </Link>
             <span>/</span>
             <Link
               href={`/knowledge/guides?category=${metadata.category}`}
-              className="hover:text-blue-600 flex items-center gap-1"
+              className="hover:text-action flex items-center gap-1"
             >
               <span>{categoryInfo.icon}</span>
               <span>{categoryInfo.label}</span>
@@ -277,7 +277,7 @@ export default async function GuidePage({ params }: GuidePageProps) {
 
           {/* Prerequisites */}
           {metadata.prerequisites && metadata.prerequisites.length > 0 && (
-            <div className="mt-6 p-4 bg-white/50 rounded-lg border border-blue-100">
+            <div className="mt-6 p-4 bg-white/50 rounded-lg border border-edge">
               <h3 className="text-sm font-semibold text-gray-900 mb-2">Prerequisites</h3>
               <ul className="flex flex-wrap gap-2">
                 {metadata.prerequisites.map((prereq) => (
@@ -355,13 +355,13 @@ export default async function GuidePage({ params }: GuidePageProps) {
                 <Link
                   key={relatedGuide.slug}
                   href={`/knowledge/guides/${relatedGuide.slug}`}
-                  className="group p-6 bg-white rounded-xl border border-gray-200 hover:border-blue-300 hover:shadow-lg transition-all"
+                  className="group p-6 bg-white rounded-xl border border-gray-200 hover:border-action hover:shadow-lg transition-all"
                 >
                   <div className="flex items-center gap-2 mb-3">
                     <span className="text-lg">{categoryConfig[relatedGuide.category].icon}</span>
                     <DifficultyBadge level={relatedGuide.difficulty} size="sm" />
                   </div>
-                  <h3 className="font-semibold text-gray-900 group-hover:text-blue-600 transition-colors mb-2">
+                  <h3 className="font-semibold text-gray-900 group-hover:text-action transition-colors mb-2">
                     {relatedGuide.title}
                   </h3>
                   <p className="text-sm text-gray-600 line-clamp-2">{relatedGuide.description}</p>
@@ -372,21 +372,21 @@ export default async function GuidePage({ params }: GuidePageProps) {
         )}
 
         {/* CTA Section */}
-        <div className="mt-16 rounded-2xl bg-gradient-to-r from-blue-600 to-purple-600 p-8 text-center text-white">
+        <div className="mt-16 rounded-2xl bg-action p-8 text-center text-white">
           <h2 className="text-2xl font-bold mb-4">Ready to Build?</h2>
-          <p className="text-blue-100 mb-6 max-w-xl mx-auto">
+          <p className="text-paper mb-6 max-w-xl mx-auto">
             Put what you&apos;ve learned into practice. Start building your AI infrastructure today.
           </p>
           <div className="flex flex-wrap justify-center gap-4">
             <Link
               href="/knowledge/guides"
-              className="inline-flex items-center px-6 py-3 bg-white text-blue-600 font-semibold rounded-lg hover:bg-gray-100 transition-colors"
+              className="inline-flex items-center px-6 py-3 bg-white text-action font-semibold rounded-lg hover:bg-gray-100 transition-colors"
             >
               Browse More Guides
             </Link>
             <Link
               href="/contact"
-              className="inline-flex items-center px-6 py-3 bg-blue-500 text-white font-semibold rounded-lg hover:bg-blue-400 transition-colors"
+              className="inline-flex items-center px-6 py-3 bg-action text-white font-semibold rounded-lg hover:bg-action-hover transition-colors"
             >
               Get Help
             </Link>

--- a/app/knowledge/guides/page.tsx
+++ b/app/knowledge/guides/page.tsx
@@ -41,7 +41,7 @@ export default async function GuidesPage({ searchParams }: GuidesPageProps) {
       <div className="bg-gradient-to-r from-amber-50 to-yellow-50 border-b border-amber-100">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
           <nav className="flex items-center gap-2 text-sm text-gray-500 mb-6">
-            <Link href="/knowledge" className="hover:text-blue-600">
+            <Link href="/knowledge" className="hover:text-action">
               Knowledge
             </Link>
             <span>/</span>
@@ -112,7 +112,7 @@ export default async function GuidesPage({ searchParams }: GuidesPageProps) {
                   href={`/knowledge/guides?category=${key}${difficultyFilter ? `&difficulty=${difficultyFilter}` : ''}`}
                   className={`px-3 py-1.5 rounded-full text-sm transition-colors flex items-center gap-1 ${
                     categoryFilter === key
-                      ? 'bg-blue-600 text-white'
+                      ? 'bg-action text-white'
                       : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                   }`}
                 >
@@ -147,7 +147,7 @@ export default async function GuidesPage({ searchParams }: GuidesPageProps) {
             {(difficultyFilter || categoryFilter) && (
               <Link
                 href="/knowledge/guides"
-                className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+                className="inline-flex items-center px-4 py-2 bg-action text-white rounded-lg hover:bg-action-hover transition-colors"
               >
                 Clear filters
               </Link>
@@ -156,15 +156,15 @@ export default async function GuidesPage({ searchParams }: GuidesPageProps) {
         )}
 
         {/* CTA Section */}
-        <div className="mt-16 rounded-2xl bg-gradient-to-r from-blue-600 to-purple-600 p-8 text-center text-white">
+        <div className="mt-16 rounded-2xl bg-action p-8 text-center text-white">
           <h2 className="text-2xl font-bold mb-4">Need Help?</h2>
-          <p className="text-blue-100 mb-6 max-w-xl mx-auto">
+          <p className="text-paper mb-6 max-w-xl mx-auto">
             Can&apos;t find what you&apos;re looking for? Our team is here to help you build your AI
             infrastructure.
           </p>
           <Link
             href="/contact"
-            className="inline-flex items-center px-6 py-3 bg-white text-blue-600 font-semibold rounded-lg hover:bg-gray-100 transition-colors"
+            className="inline-flex items-center px-6 py-3 bg-white text-action font-semibold rounded-lg hover:bg-gray-100 transition-colors"
           >
             Contact Us
           </Link>

--- a/app/knowledge/infrastructure/page.tsx
+++ b/app/knowledge/infrastructure/page.tsx
@@ -16,10 +16,10 @@ export default async function InfrastructurePage() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-gray-50 to-white">
       {/* Hero Section */}
-      <div className="bg-gradient-to-r from-purple-50 to-indigo-50 border-b border-purple-100">
+      <div className="bg-action-tint border-b border-edge">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
           <nav className="flex items-center gap-2 text-sm text-gray-500 mb-6">
-            <Link href="/knowledge" className="hover:text-blue-600">
+            <Link href="/knowledge" className="hover:text-action">
               Knowledge
             </Link>
             <span>/</span>
@@ -73,8 +73,8 @@ export default async function InfrastructurePage() {
 
             {/* Cloud Managed Card */}
             <div className="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg transition-shadow">
-              <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mb-4">
-                <CloudIcon className="w-6 h-6 text-blue-600" />
+              <div className="w-12 h-12 bg-action-tint rounded-lg flex items-center justify-center mb-4">
+                <CloudIcon className="w-6 h-6 text-action" />
               </div>
               <h3 className="text-lg font-semibold text-gray-900 mb-2">Cloud Managed</h3>
               <p className="text-gray-600 mb-4">
@@ -142,21 +142,21 @@ export default async function InfrastructurePage() {
             {/* Hosting Comparison */}
             <Link
               href={'/knowledge/infrastructure/hosting-comparison' as Route}
-              className="group bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg hover:border-blue-300 transition-all"
+              className="group bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg hover:border-action transition-all"
             >
               <div className="flex items-start gap-4">
-                <div className="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center flex-shrink-0">
+                <div className="w-12 h-12 bg-action-tint rounded-lg flex items-center justify-center flex-shrink-0">
                   <span className="text-2xl">🏗️</span>
                 </div>
                 <div className="flex-1 min-w-0">
-                  <h3 className="text-lg font-semibold text-gray-900 group-hover:text-blue-600 transition-colors mb-2">
+                  <h3 className="text-lg font-semibold text-gray-900 group-hover:text-action transition-colors mb-2">
                     Hosting Comparison
                   </h3>
                   <p className="text-gray-600 text-sm mb-4">
                     Compare self-hosted, cloud, and serverless options. Understand the trade-offs
                     between Vercel, AWS, GCP, and running your own servers.
                   </p>
-                  <div className="flex items-center text-sm text-blue-600 font-medium">
+                  <div className="flex items-center text-sm text-action font-medium">
                     Read comparison
                     <ArrowRightIcon className="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform" />
                   </div>
@@ -167,21 +167,21 @@ export default async function InfrastructurePage() {
             {/* Model Comparison */}
             <Link
               href={'/knowledge/infrastructure/model-comparison' as Route}
-              className="group bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg hover:border-blue-300 transition-all"
+              className="group bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg hover:border-action transition-all"
             >
               <div className="flex items-start gap-4">
-                <div className="w-12 h-12 bg-indigo-100 rounded-lg flex items-center justify-center flex-shrink-0">
+                <div className="w-12 h-12 bg-action-tint rounded-lg flex items-center justify-center flex-shrink-0">
                   <span className="text-2xl">🤖</span>
                 </div>
                 <div className="flex-1 min-w-0">
-                  <h3 className="text-lg font-semibold text-gray-900 group-hover:text-blue-600 transition-colors mb-2">
+                  <h3 className="text-lg font-semibold text-gray-900 group-hover:text-action transition-colors mb-2">
                     AI Model Comparison
                   </h3>
                   <p className="text-gray-600 text-sm mb-4">
                     OpenAI vs Claude vs open source. Compare GPT-4, Claude 3, Llama 3, Mistral by
                     quality, cost, speed, and privacy.
                   </p>
-                  <div className="flex items-center text-sm text-blue-600 font-medium">
+                  <div className="flex items-center text-sm text-action font-medium">
                     Read comparison
                     <ArrowRightIcon className="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform" />
                   </div>
@@ -192,21 +192,21 @@ export default async function InfrastructurePage() {
             {/* Cost Estimation */}
             <Link
               href={'/knowledge/infrastructure/cost-estimation' as Route}
-              className="group bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg hover:border-blue-300 transition-all"
+              className="group bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg hover:border-action transition-all"
             >
               <div className="flex items-start gap-4">
                 <div className="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center flex-shrink-0">
                   <span className="text-2xl">💰</span>
                 </div>
                 <div className="flex-1 min-w-0">
-                  <h3 className="text-lg font-semibold text-gray-900 group-hover:text-blue-600 transition-colors mb-2">
+                  <h3 className="text-lg font-semibold text-gray-900 group-hover:text-action transition-colors mb-2">
                     Cost Estimation Guide
                   </h3>
                   <p className="text-gray-600 text-sm mb-4">
                     Understand token pricing, estimate monthly costs for different usage levels, and
                     discover hidden infrastructure costs.
                   </p>
-                  <div className="flex items-center text-sm text-blue-600 font-medium">
+                  <div className="flex items-center text-sm text-action font-medium">
                     Read guide
                     <ArrowRightIcon className="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform" />
                   </div>
@@ -217,21 +217,21 @@ export default async function InfrastructurePage() {
             {/* Security Best Practices */}
             <Link
               href={'/knowledge/infrastructure/security' as Route}
-              className="group bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg hover:border-blue-300 transition-all"
+              className="group bg-white rounded-xl border border-gray-200 p-6 hover:shadow-lg hover:border-action transition-all"
             >
               <div className="flex items-start gap-4">
                 <div className="w-12 h-12 bg-red-100 rounded-lg flex items-center justify-center flex-shrink-0">
                   <span className="text-2xl">🔒</span>
                 </div>
                 <div className="flex-1 min-w-0">
-                  <h3 className="text-lg font-semibold text-gray-900 group-hover:text-blue-600 transition-colors mb-2">
+                  <h3 className="text-lg font-semibold text-gray-900 group-hover:text-action transition-colors mb-2">
                     Security Best Practices
                   </h3>
                   <p className="text-gray-600 text-sm mb-4">
                     Secure your AI infrastructure. API key management, data encryption, rate
                     limiting, and compliance considerations.
                   </p>
-                  <div className="flex items-center text-sm text-blue-600 font-medium">
+                  <div className="flex items-center text-sm text-action font-medium">
                     Read guide
                     <ArrowRightIcon className="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform" />
                   </div>
@@ -417,22 +417,22 @@ export default async function InfrastructurePage() {
         </div>
 
         {/* CTA Section */}
-        <div className="rounded-2xl bg-gradient-to-r from-purple-600 to-indigo-600 p-8 text-center text-white">
+        <div className="rounded-2xl bg-action p-8 text-center text-white">
           <h2 className="text-2xl font-bold mb-4">Need Help Deciding?</h2>
-          <p className="text-purple-100 mb-6 max-w-xl mx-auto">
+          <p className="text-paper mb-6 max-w-xl mx-auto">
             Not sure which infrastructure is right for your project? We can help you evaluate
             options and make the right choice.
           </p>
           <div className="flex flex-wrap justify-center gap-4">
             <Link
               href="/knowledge/guides?category=infrastructure"
-              className="inline-flex items-center px-6 py-3 bg-white text-purple-600 font-semibold rounded-lg hover:bg-gray-100 transition-colors"
+              className="inline-flex items-center px-6 py-3 bg-white text-action font-semibold rounded-lg hover:bg-gray-100 transition-colors"
             >
               Browse Infrastructure Guides
             </Link>
             <Link
               href="/contact"
-              className="inline-flex items-center px-6 py-3 bg-purple-500 text-white font-semibold rounded-lg hover:bg-purple-400 transition-colors"
+              className="inline-flex items-center px-6 py-3 bg-action text-white font-semibold rounded-lg hover:bg-action-hover transition-colors"
             >
               Talk to an Expert
             </Link>
@@ -451,7 +451,7 @@ function DifficultyDot({ level }: { level: 'easy' | 'medium' | 'hard' | 'low' | 
     hard: 'bg-red-500',
     low: 'bg-amber-500',
     high: 'bg-green-500',
-    full: 'bg-blue-500',
+    full: 'bg-action',
   };
 
   return (

--- a/app/knowledge/page.tsx
+++ b/app/knowledge/page.tsx
@@ -180,7 +180,7 @@ export default function KnowledgeCenterPage() {
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-emerald-50">
       {/* Background Effects */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute -top-40 -right-40 w-80 h-80 bg-gradient-to-br from-emerald-400 to-teal-600 rounded-full opacity-10 blur-3xl"></div>
+        <div className="absolute -top-40 -right-40 w-80 h-80 bg-gradient-to-br from-emerald-400 to-action-hover rounded-full opacity-10 blur-3xl"></div>
         <div className="absolute -bottom-40 -left-40 w-96 h-96 bg-gradient-to-tr from-green-400 to-emerald-600 rounded-full opacity-10 blur-3xl"></div>
       </div>
 
@@ -193,13 +193,8 @@ export default function KnowledgeCenterPage() {
           </div>
 
           <h1 className="text-5xl md:text-6xl font-bold mb-6">
-            <span className="bg-gradient-to-r from-gray-900 to-gray-600 bg-clip-text text-transparent">
-              Knowledge
-            </span>
-            <span className="bg-gradient-to-r from-emerald-600 to-teal-600 bg-clip-text text-transparent">
-              {' '}
-              Center
-            </span>
+            <span className="text-ink">Knowledge</span>
+            <span className="text-ink"> Center</span>
           </h1>
 
           <p className="text-xl text-gray-600 max-w-3xl mx-auto mb-8">
@@ -210,7 +205,7 @@ export default function KnowledgeCenterPage() {
           <div className="flex flex-wrap justify-center gap-4">
             <a
               href="#guides"
-              className="inline-flex items-center gap-2 bg-gradient-to-r from-emerald-600 to-teal-600 text-white px-6 py-3 rounded-xl font-semibold hover:opacity-90 transition-opacity"
+              className="inline-flex items-center gap-2 bg-gradient-to-r from-emerald-600 to-action-hover text-white px-6 py-3 rounded-xl font-semibold hover:opacity-90 transition-opacity"
             >
               <span>Browse Guides</span>
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -235,13 +230,8 @@ export default function KnowledgeCenterPage() {
         <section id="guides" className="mb-24">
           <div className="text-center mb-12">
             <h2 className="text-4xl font-bold mb-4">
-              <span className="bg-gradient-to-r from-gray-900 to-gray-600 bg-clip-text text-transparent">
-                Step-by-Step
-              </span>
-              <span className="bg-gradient-to-r from-emerald-600 to-teal-600 bg-clip-text text-transparent">
-                {' '}
-                Guides
-              </span>
+              <span className="text-ink">Step-by-Step</span>
+              <span className="text-ink"> Guides</span>
             </h2>
             <p className="text-gray-600 max-w-2xl mx-auto">
               Practical tutorials to help you build and deploy AI bots yourself. From beginner to
@@ -306,13 +296,8 @@ export default function KnowledgeCenterPage() {
         <section id="faq" className="mb-24">
           <div className="text-center mb-12">
             <h2 className="text-4xl font-bold mb-4">
-              <span className="bg-gradient-to-r from-gray-900 to-gray-600 bg-clip-text text-transparent">
-                Frequently Asked
-              </span>
-              <span className="bg-gradient-to-r from-emerald-600 to-teal-600 bg-clip-text text-transparent">
-                {' '}
-                Questions
-              </span>
+              <span className="text-ink">Frequently Asked</span>
+              <span className="text-ink"> Questions</span>
             </h2>
             <p className="text-gray-600 max-w-2xl mx-auto">
               Quick answers to common questions about AI bots, our platform, and consulting
@@ -379,7 +364,7 @@ export default function KnowledgeCenterPage() {
         </section>
 
         {/* CTA Section */}
-        <section className="text-center bg-gradient-to-br from-emerald-50 to-teal-50 rounded-3xl p-12">
+        <section className="text-center bg-gradient-to-br from-emerald-50 to-action-tint rounded-3xl p-12">
           <h2 className="text-3xl font-bold text-gray-900 mb-4">Still have questions?</h2>
           <p className="text-gray-600 mb-8 max-w-xl mx-auto">
             Our team is here to help. Whether you want to build it yourself or need expert
@@ -388,7 +373,7 @@ export default function KnowledgeCenterPage() {
           <div className="flex flex-col sm:flex-row justify-center gap-4">
             <Link
               href="/contact"
-              className="inline-flex items-center justify-center gap-2 bg-gradient-to-r from-emerald-600 to-teal-600 text-white px-8 py-4 rounded-xl font-semibold hover:opacity-90 transition-opacity"
+              className="inline-flex items-center justify-center gap-2 bg-gradient-to-r from-emerald-600 to-action-hover text-white px-8 py-4 rounded-xl font-semibold hover:opacity-90 transition-opacity"
             >
               <span>Talk to an Expert</span>
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/my-data/page.tsx
+++ b/app/my-data/page.tsx
@@ -51,7 +51,7 @@ export default function MyDataPage() {
   const hasReadyDocuments = (documents || []).some((d) => d.status === DOCUMENT_STATUS.READY);
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white">
+    <div className="min-h-screen bg-gradient-to-b from-action-tint to-white">
       <div className="max-w-6xl mx-auto px-4 py-8">
         {/* Page Header with User Controls */}
         <div className="flex items-center justify-between mb-6">
@@ -62,7 +62,7 @@ export default function MyDataPage() {
             </p>
           </div>
           <div className="flex items-center gap-4">
-            <Link href="/professionals" className="text-sm text-blue-600 hover:text-blue-700">
+            <Link href="/professionals" className="text-sm text-action hover:text-action">
               AI Professionals
             </Link>
             <Link href="/settings" className="text-sm text-gray-500 hover:text-gray-700">
@@ -125,11 +125,11 @@ export default function MyDataPage() {
         </div>
 
         {/* Info Box */}
-        <div className="mt-8 bg-blue-50 rounded-xl p-6 border border-blue-100">
-          <h3 className="font-semibold text-blue-900 mb-2">
+        <div className="mt-8 bg-action-tint rounded-xl p-6 border border-edge">
+          <h3 className="font-semibold text-action mb-2">
             How to personalize your AI Professionals
           </h3>
-          <ol className="list-decimal list-inside space-y-2 text-blue-800">
+          <ol className="list-decimal list-inside space-y-2 text-action">
             <li>Upload your documents (contracts, medical records, research papers, etc.)</li>
             <li>Click &quot;Process&quot; to extract and index the content securely</li>
             <li>Your AI Professionals will use this knowledge to provide personalized guidance</li>
@@ -137,7 +137,7 @@ export default function MyDataPage() {
           <div className="mt-4">
             <Link
               href="/professionals"
-              className="inline-flex items-center gap-2 text-blue-600 hover:text-blue-700 font-medium"
+              className="inline-flex items-center gap-2 text-action hover:text-action font-medium"
             >
               Talk to an AI Professional
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/app/personal/page.tsx
+++ b/app/personal/page.tsx
@@ -64,11 +64,11 @@ export default function PersonalPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-purple-50">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-action-tint">
       {/* Background Effects */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute -top-40 -right-40 w-80 h-80 bg-gradient-to-br from-purple-400 to-pink-600 rounded-full opacity-10 blur-3xl" />
-        <div className="absolute -bottom-40 -left-40 w-96 h-96 bg-gradient-to-tr from-blue-400 to-cyan-600 rounded-full opacity-10 blur-3xl" />
+        <div className="absolute -top-40 -right-40 w-80 h-80 bg-gradient-to-br from-action to-action-hover rounded-full opacity-10 blur-3xl" />
+        <div className="absolute -bottom-40 -left-40 w-96 h-96 bg-action rounded-full opacity-10 blur-3xl" />
       </div>
 
       <main className="relative max-w-screen-xl mx-auto px-6 py-12">
@@ -111,9 +111,7 @@ export default function PersonalPage() {
         {step === 'pick' && (
           <div className="text-center mb-12">
             <h1 className="text-3xl md:text-4xl font-bold mb-4">
-              <span className="bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent">
-                Personal AI
-              </span>
+              <span className="text-action">Personal AI</span>
             </h1>
             <p className="text-gray-600 max-w-lg mx-auto">
               Create memorial bots for loved ones, companion bots, and other personal AI assistants
@@ -125,11 +123,11 @@ export default function PersonalPage() {
         {/* Progress Indicator */}
         <div className="flex items-center justify-center gap-4 mb-12">
           <div
-            className={`flex items-center gap-2 ${step === 'pick' ? 'text-purple-600' : 'text-gray-400'}`}
+            className={`flex items-center gap-2 ${step === 'pick' ? 'text-action' : 'text-gray-400'}`}
           >
             <div
               className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold ${
-                step === 'pick' ? 'bg-purple-600 text-white' : 'bg-gray-200 text-gray-500'
+                step === 'pick' ? 'bg-action text-white' : 'bg-gray-200 text-gray-500'
               }`}
             >
               1
@@ -137,17 +135,17 @@ export default function PersonalPage() {
             <span className="hidden sm:inline font-medium">Choose</span>
           </div>
 
-          <div className={`w-12 h-0.5 ${step !== 'pick' ? 'bg-purple-600' : 'bg-gray-200'}`} />
+          <div className={`w-12 h-0.5 ${step !== 'pick' ? 'bg-action' : 'bg-gray-200'}`} />
 
           <div
-            className={`flex items-center gap-2 ${step === 'name' ? 'text-purple-600' : 'text-gray-400'}`}
+            className={`flex items-center gap-2 ${step === 'name' ? 'text-action' : 'text-gray-400'}`}
           >
             <div
               className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold ${
                 step === 'name'
-                  ? 'bg-purple-600 text-white'
+                  ? 'bg-action text-white'
                   : step === 'chat'
-                    ? 'bg-purple-600 text-white'
+                    ? 'bg-action text-white'
                     : 'bg-gray-200 text-gray-500'
               }`}
             >
@@ -156,14 +154,14 @@ export default function PersonalPage() {
             <span className="hidden sm:inline font-medium">Name</span>
           </div>
 
-          <div className={`w-12 h-0.5 ${step === 'chat' ? 'bg-purple-600' : 'bg-gray-200'}`} />
+          <div className={`w-12 h-0.5 ${step === 'chat' ? 'bg-action' : 'bg-gray-200'}`} />
 
           <div
-            className={`flex items-center gap-2 ${step === 'chat' ? 'text-purple-600' : 'text-gray-400'}`}
+            className={`flex items-center gap-2 ${step === 'chat' ? 'text-action' : 'text-gray-400'}`}
           >
             <div
               className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold ${
-                step === 'chat' ? 'bg-purple-600 text-white' : 'bg-gray-200 text-gray-500'
+                step === 'chat' ? 'bg-action text-white' : 'bg-gray-200 text-gray-500'
               }`}
             >
               3
@@ -186,7 +184,7 @@ export default function PersonalPage() {
           <div className="mt-16 text-center">
             <p className="text-gray-500 text-sm">
               Looking for professional AI advisors?{' '}
-              <Link href="/professionals" className="text-purple-600 hover:text-purple-700">
+              <Link href="/professionals" className="text-action hover:text-action">
                 Visit our AI Professionals
               </Link>
             </p>

--- a/app/professionals/[slug]/page.tsx
+++ b/app/professionals/[slug]/page.tsx
@@ -48,14 +48,12 @@ export default async function ProfessionalPage({ params }: PageProps) {
   const colors = getAccentColorClasses(professional.accentColor);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-action-tint">
       {/* Navigation Bar */}
       <nav className="fixed top-0 left-0 right-0 z-50 bg-white/95 backdrop-blur-2xl border-b border-gray-100/50 shadow-sm">
         <div className="max-w-screen-xl mx-auto px-6 h-16 flex items-center justify-between">
           <Link href="/" className="flex items-center gap-2">
-            <span className="text-2xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
-              Botsmann
-            </span>
+            <span className="text-2xl font-bold text-action">Botsmann</span>
           </Link>
           <div className="flex items-center gap-4">
             <Link
@@ -87,9 +85,7 @@ export default async function ProfessionalPage({ params }: PageProps) {
               </div>
 
               <h1 className="text-4xl md:text-5xl font-bold mb-4">
-                <span className="bg-gradient-to-r from-gray-900 to-gray-700 bg-clip-text text-transparent">
-                  {professional.name}
-                </span>
+                <span className="text-ink">{professional.name}</span>
               </h1>
 
               <p className={`text-xl ${colors.text} font-semibold mb-4`}>{professional.title}</p>
@@ -193,7 +189,7 @@ export default async function ProfessionalPage({ params }: PageProps) {
           </section>
 
           {/* How to Get the Most */}
-          <section className="mb-16 bg-gradient-to-br from-gray-50 to-blue-50 rounded-2xl p-8">
+          <section className="mb-16 bg-gradient-to-br from-gray-50 to-action-tint rounded-2xl p-8">
             <h2 className="text-2xl font-bold mb-6 text-gray-900">
               Get the Most Out of {professional.name}
             </h2>

--- a/app/professionals/page.tsx
+++ b/app/professionals/page.tsx
@@ -15,20 +15,18 @@ export const metadata: Metadata = {
  */
 export default function ProfessionalsPage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-action-tint">
       {/* Background Effects */}
       <div className="absolute inset-0 overflow-hidden pointer-events-none">
-        <div className="absolute -top-40 -right-40 w-80 h-80 bg-gradient-to-br from-blue-400 to-purple-600 rounded-full opacity-10 blur-3xl" />
-        <div className="absolute -bottom-40 -left-40 w-96 h-96 bg-gradient-to-tr from-cyan-400 to-blue-600 rounded-full opacity-10 blur-3xl" />
+        <div className="absolute -top-40 -right-40 w-80 h-80 bg-action rounded-full opacity-10 blur-3xl" />
+        <div className="absolute -bottom-40 -left-40 w-96 h-96 bg-gradient-to-tr from-action to-action-hover rounded-full opacity-10 blur-3xl" />
       </div>
 
       <main className="relative max-w-screen-xl mx-auto px-6 py-20">
         {/* Hero */}
         <section className="text-center mb-16 pt-8">
           <h1 className="text-4xl md:text-5xl font-bold mb-6">
-            <span className="bg-gradient-to-r from-gray-900 via-blue-900 to-purple-900 bg-clip-text text-transparent">
-              Choose Your AI Professional
-            </span>
+            <span className="text-ink">Choose Your AI Professional</span>
           </h1>
           <p className="text-xl text-gray-600 max-w-2xl mx-auto">
             Each professional brings specialized knowledge, expert guidance, and a unique approach
@@ -38,7 +36,7 @@ export default function ProfessionalsPage() {
 
         {/* Filter Tabs (future enhancement - for now just show all) */}
         <div className="flex justify-center gap-2 mb-12">
-          <button className="px-4 py-2 rounded-full bg-blue-600 text-white font-medium">All</button>
+          <button className="px-4 py-2 rounded-full bg-action text-white font-medium">All</button>
           <button className="px-4 py-2 rounded-full bg-gray-100 text-gray-600 font-medium hover:bg-gray-200 transition-colors">
             Advisory
           </button>
@@ -68,7 +66,7 @@ export default function ProfessionalsPage() {
             <div className="flex flex-col sm:flex-row justify-center gap-4">
               <Link
                 href="/professionals/legal"
-                className="inline-flex items-center justify-center gap-2 bg-blue-600 text-white px-6 py-3 rounded-xl font-semibold hover:bg-blue-700 transition-colors"
+                className="inline-flex items-center justify-center gap-2 bg-action text-white px-6 py-3 rounded-xl font-semibold hover:bg-action-hover transition-colors"
               >
                 <span>⚖️</span>
                 Start with Legal

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -95,7 +95,7 @@ export default function ProfilePage() {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white">
+    <div className="min-h-screen bg-gradient-to-b from-action-tint to-white">
       <div className="max-w-4xl mx-auto px-4 py-8">
         {/* Profile Header */}
         <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">
@@ -147,10 +147,7 @@ export default function ProfilePage() {
         <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-semibold text-gray-900">Published Bots</h2>
-            <Link
-              href="/bots/create"
-              className="text-blue-600 hover:text-blue-700 text-sm font-medium"
-            >
+            <Link href="/bots/create" className="text-action hover:text-action text-sm font-medium">
               Create new
             </Link>
           </div>
@@ -166,7 +163,7 @@ export default function ProfilePage() {
               </p>
               <Link
                 href="/bots/create"
-                className="inline-block mt-4 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors"
+                className="inline-block mt-4 px-4 py-2 bg-action text-white rounded-lg text-sm font-medium hover:bg-action-hover transition-colors"
               >
                 Create Your First Bot
               </Link>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -132,7 +132,7 @@ export default function SettingsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-blue-50 to-white">
+    <div className="min-h-screen bg-gradient-to-b from-action-tint to-white">
       <div className="max-w-2xl mx-auto px-4 py-8">
         {/* Page Header */}
         <div className="mb-8">
@@ -147,7 +147,7 @@ export default function SettingsPage() {
             {!isEditingProfile && (
               <button
                 onClick={() => setIsEditingProfile(true)}
-                className="text-blue-600 hover:text-blue-700 text-sm font-medium"
+                className="text-action hover:text-action text-sm font-medium"
               >
                 Edit
               </button>
@@ -198,7 +198,7 @@ export default function SettingsPage() {
                       onChange={(e) => setProfileDisplayName(e.target.value)}
                       maxLength={DISPLAY_NAME_MAX_LENGTH}
                       placeholder="Your name"
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-action"
                     />
                     <p className="text-xs text-gray-500 mt-1">
                       {profileDisplayName.length}/{DISPLAY_NAME_MAX_LENGTH} characters
@@ -218,7 +218,7 @@ export default function SettingsPage() {
                       value={profileAvatarUrl}
                       onChange={(e) => setProfileAvatarUrl(e.target.value)}
                       placeholder="https://example.com/avatar.jpg"
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-action"
                     />
                     <p className="text-xs text-gray-500 mt-1">
                       Enter a URL to an image (PNG, JPG, or GIF)
@@ -231,7 +231,7 @@ export default function SettingsPage() {
                 <button
                   type="submit"
                   disabled={profileSaving}
-                  className="px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                  className="px-4 py-2 bg-action text-white rounded-lg font-medium hover:bg-action-hover disabled:opacity-50 transition-colors"
                 >
                   {profileSaving ? 'Saving...' : 'Save Profile'}
                 </button>
@@ -303,7 +303,7 @@ export default function SettingsPage() {
           <div className="mt-6">
             <Link
               href="/documents"
-              className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors"
+              className="inline-flex items-center gap-2 px-4 py-2 bg-action text-white rounded-lg text-sm font-medium hover:bg-action-hover transition-colors"
             >
               Go to My Documents
               <ChevronRightIcon className="w-4 h-4" />

--- a/app/try/page.tsx
+++ b/app/try/page.tsx
@@ -11,14 +11,11 @@ export default function TryPage() {
   const [success, setSuccess] = useState('');
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50">
+    <div className="min-h-screen bg-gradient-to-br from-action-tint via-white to-action-tint">
       {/* Header */}
       <header className="border-b border-gray-100 bg-white/80 backdrop-blur-sm sticky top-0 z-10">
         <div className="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
-          <Link
-            href="/"
-            className="text-xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent"
-          >
+          <Link href="/" className="text-xl font-bold text-action">
             Botsmann
           </Link>
           <div className="flex items-center gap-4">
@@ -30,7 +27,7 @@ export default function TryPage() {
             </Link>
             <Link
               href="/auth/signup"
-              className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors"
+              className="bg-action text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-action-hover transition-colors"
             >
               Create Account
             </Link>
@@ -42,9 +39,7 @@ export default function TryPage() {
         {/* Hero */}
         <div className="text-center mb-8">
           <h1 className="text-3xl md:text-4xl font-bold mb-4">
-            <span className="bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
-              Chat With Your Documents
-            </span>
+            <span className="text-action">Chat With Your Documents</span>
           </h1>
           <p className="text-gray-600 text-lg max-w-2xl mx-auto">
             Upload any text document and ask questions about it. No account required. Your documents
@@ -83,19 +78,19 @@ export default function TryPage() {
 
         {/* Info Section */}
         <div className="mt-8 max-w-4xl mx-auto">
-          <div className="bg-gradient-to-r from-blue-50 to-purple-50 rounded-2xl p-6 border border-blue-100">
+          <div className="bg-action-tint rounded-2xl p-6 border border-edge">
             <h3 className="font-bold text-gray-900 mb-4">How it works</h3>
             <ol className="list-decimal list-inside space-y-2 text-gray-700">
               <li>Upload one or more documents (PDF, TXT, or Markdown)</li>
               <li>Ask questions about the content in natural language</li>
               <li>Get AI-powered answers based on your documents</li>
             </ol>
-            <div className="mt-4 pt-4 border-t border-blue-200">
+            <div className="mt-4 pt-4 border-t border-edge">
               <p className="text-sm text-gray-600">
                 <strong>Privacy:</strong> Your documents are processed in your browser and sent
                 directly to the AI. Nothing is stored on our servers. For persistent storage and
                 advanced features,{' '}
-                <Link href="/auth/signup" className="text-blue-600 hover:underline">
+                <Link href="/auth/signup" className="text-action hover:underline">
                   create a free account
                 </Link>
                 .

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -82,7 +82,7 @@ function ErrorFallback({ onReset, error }: ErrorFallbackProps): ReactNode {
         <div className="flex flex-col sm:flex-row gap-3 justify-center">
           <button
             onClick={onReset}
-            className="px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors"
+            className="px-6 py-3 bg-action text-white font-medium rounded-lg hover:bg-action-hover transition-colors"
           >
             Try Again
           </button>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -43,7 +43,7 @@ export function Navigation() {
       {/* Mobile Menu Button */}
       <button
         type="button"
-        className="lg:hidden rounded-md p-2 text-gray-600 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="lg:hidden rounded-md p-2 text-gray-600 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-action"
         onClick={() => setMobileMenuOpen(true)}
         aria-label="Open menu"
       >

--- a/components/blog/MDXComponents.tsx
+++ b/components/blog/MDXComponents.tsx
@@ -246,7 +246,7 @@ const MDXComponents = {
     type?: 'info' | 'warning' | 'success';
   }) => {
     const styles = {
-      info: 'bg-blue-50 border-blue-200 text-blue-800',
+      info: 'bg-action-tint border-edge text-action',
       warning: 'bg-yellow-50 border-yellow-200 text-yellow-800',
       success: 'bg-green-50 border-green-200 text-green-800',
     };

--- a/components/blog/ServerMDXContent.tsx
+++ b/components/blog/ServerMDXContent.tsx
@@ -113,7 +113,7 @@ const ServerMDXComponents = {
     type?: 'info' | 'warning' | 'success';
   }) => {
     const styles = {
-      info: 'bg-blue-50 border-blue-200 text-blue-800',
+      info: 'bg-action-tint border-edge text-action',
       warning: 'bg-yellow-50 border-yellow-200 text-yellow-800',
       success: 'bg-green-50 border-green-200 text-green-800',
     };

--- a/components/chat/ChatAuthCTA.tsx
+++ b/components/chat/ChatAuthCTA.tsx
@@ -30,9 +30,7 @@ export const ChatAuthCTA: FC<ChatAuthCTAProps> = ({ dismissible = true, classNam
   }
 
   return (
-    <div
-      className={`relative bg-gradient-to-r from-indigo-50 to-purple-50 border border-indigo-100 rounded-xl p-4 ${className}`}
-    >
+    <div className={`relative bg-action-tint border border-edge rounded-xl p-4 ${className}`}>
       {dismissible && (
         <button
           type="button"
@@ -52,9 +50,9 @@ export const ChatAuthCTA: FC<ChatAuthCTAProps> = ({ dismissible = true, classNam
       )}
 
       <div className="flex items-start gap-3">
-        <div className="flex-shrink-0 w-10 h-10 rounded-full bg-indigo-100 flex items-center justify-center">
+        <div className="flex-shrink-0 w-10 h-10 rounded-full bg-action-tint flex items-center justify-center">
           <svg
-            className="w-5 h-5 text-indigo-600"
+            className="w-5 h-5 text-action"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -94,7 +92,7 @@ export const ChatAuthCTA: FC<ChatAuthCTAProps> = ({ dismissible = true, classNam
           <div className="flex flex-wrap gap-2">
             <Link
               href={config.primaryAction.href}
-              className="inline-flex items-center px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors"
+              className="inline-flex items-center px-4 py-2 bg-action text-white text-sm font-medium rounded-lg hover:bg-action-hover transition-colors"
             >
               {config.primaryAction.label}
             </Link>

--- a/components/chat/ModelIndicator.tsx
+++ b/components/chat/ModelIndicator.tsx
@@ -47,7 +47,7 @@ export const ModelIndicator: FC<ModelIndicatorProps> = ({
           className={`px-2 py-0.5 rounded text-xs font-medium ${
             tier.privacyLevel === 'maximum'
               ? 'bg-green-100 text-green-700'
-              : 'bg-blue-100 text-blue-700'
+              : 'bg-action-tint text-action'
           }`}
         >
           {tier.privacyLevel === 'maximum' ? 'Private' : 'Cloud'}

--- a/components/chat/ModelSelector.tsx
+++ b/components/chat/ModelSelector.tsx
@@ -81,7 +81,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
           className={`px-1.5 py-0.5 rounded text-xs ${
             currentTier.privacyLevel === 'maximum'
               ? 'bg-green-100 text-green-700'
-              : 'bg-blue-100 text-blue-700'
+              : 'bg-action-tint text-action'
           }`}
         >
           {currentTier.privacyLevel === 'maximum' ? 'Private' : 'Cloud'}
@@ -145,7 +145,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
                       className={`px-1.5 py-0.5 rounded text-xs ${
                         tier.privacyLevel === 'maximum'
                           ? 'bg-green-100 text-green-700'
-                          : 'bg-blue-100 text-blue-700'
+                          : 'bg-action-tint text-action'
                       }`}
                     >
                       {tier.privacyLevel === 'maximum' ? 'Private' : 'Cloud'}

--- a/components/chat/PrivacyTierInfo.tsx
+++ b/components/chat/PrivacyTierInfo.tsx
@@ -124,7 +124,7 @@ const TierCard: FC<TierCardProps> = ({ tier }) => {
   return (
     <div
       className={`p-4 rounded-lg border ${
-        isPrivate ? 'border-green-200 bg-green-50' : 'border-blue-200 bg-blue-50'
+        isPrivate ? 'border-green-200 bg-green-50' : 'border-edge bg-action-tint'
       }`}
     >
       <div className="flex items-center gap-2 mb-2">
@@ -132,7 +132,7 @@ const TierCard: FC<TierCardProps> = ({ tier }) => {
         <h3 className="font-semibold text-gray-900">{tier.name}</h3>
         <span
           className={`px-2 py-0.5 rounded text-xs font-medium ${
-            isPrivate ? 'bg-green-200 text-green-800' : 'bg-blue-200 text-blue-800'
+            isPrivate ? 'bg-green-200 text-green-800' : 'bg-action-tint text-action'
           }`}
         >
           {tier.costIndicator}

--- a/components/conversations/ConversationItem.tsx
+++ b/components/conversations/ConversationItem.tsx
@@ -28,7 +28,7 @@ export const ConversationItem = ({
       onClick={() => onSelect(conversation.id)}
       className={`p-3 rounded-lg cursor-pointer transition-colors group ${
         isActive
-          ? 'bg-blue-100 border-blue-300 border'
+          ? 'bg-action-tint border-edge border'
           : 'bg-gray-50 hover:bg-gray-100 border border-transparent'
       }`}
     >

--- a/components/conversations/ConversationList.tsx
+++ b/components/conversations/ConversationList.tsx
@@ -98,7 +98,7 @@ export const ConversationList = ({
             e.stopPropagation();
             onNewConversation();
           }}
-          className="p-2 text-blue-600 hover:text-blue-700 hover:bg-blue-50 rounded"
+          className="p-2 text-action hover:text-action hover:bg-action-tint rounded"
           aria-label="New conversation"
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -118,7 +118,7 @@ export const ConversationList = ({
               <p>No conversations yet</p>
               <button
                 onClick={onNewConversation}
-                className="mt-2 text-blue-600 hover:text-blue-700 text-sm"
+                className="mt-2 text-action hover:text-action text-sm"
               >
                 Start a new conversation
               </button>

--- a/components/dashboard/DashboardEmptyState.tsx
+++ b/components/dashboard/DashboardEmptyState.tsx
@@ -15,8 +15,8 @@ export const DashboardEmptyState: FC<DashboardEmptyStateProps> = ({ displayName 
   return (
     <div className="space-y-6">
       {/* Main CTA Card */}
-      <div className="bg-gradient-to-br from-blue-50 via-white to-purple-50 rounded-2xl border border-blue-100 p-8 text-center">
-        <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-purple-500 rounded-2xl flex items-center justify-center mx-auto mb-6 shadow-lg">
+      <div className="bg-gradient-to-br from-action-tint via-white to-action-tint rounded-2xl border border-edge p-8 text-center">
+        <div className="w-16 h-16 bg-gradient-to-br from-action to-action-hover rounded-2xl flex items-center justify-center mx-auto mb-6 shadow-lg">
           <svg className="w-8 h-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path
               strokeLinecap="round"
@@ -39,7 +39,7 @@ export const DashboardEmptyState: FC<DashboardEmptyStateProps> = ({ displayName 
         <div className="flex flex-col sm:flex-row justify-center gap-4">
           <Link
             href="/documents"
-            className="inline-flex items-center justify-center gap-2 bg-gradient-to-r from-blue-600 to-purple-600 text-white px-6 py-3 rounded-xl font-semibold shadow-lg hover:shadow-xl transform hover:scale-105 transition-all"
+            className="inline-flex items-center justify-center gap-2 bg-gradient-to-r from-action to-action-hover text-white px-6 py-3 rounded-xl font-semibold shadow-lg hover:shadow-xl transform hover:scale-105 transition-all"
           >
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path
@@ -54,7 +54,7 @@ export const DashboardEmptyState: FC<DashboardEmptyStateProps> = ({ displayName 
 
           <Link
             href="/professionals"
-            className="inline-flex items-center justify-center gap-2 border-2 border-gray-200 hover:border-blue-300 text-gray-700 hover:text-blue-600 px-6 py-3 rounded-xl font-semibold transition-all"
+            className="inline-flex items-center justify-center gap-2 border-2 border-gray-200 hover:border-action text-gray-700 hover:text-action px-6 py-3 rounded-xl font-semibold transition-all"
           >
             <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path
@@ -82,8 +82,8 @@ export const DashboardEmptyState: FC<DashboardEmptyStateProps> = ({ displayName 
               />
             </svg>
           }
-          iconColor="text-blue-600"
-          iconBg="bg-blue-100"
+          iconColor="text-action"
+          iconBg="bg-action-tint"
           title="Analyze Documents"
           description="Upload contracts, research papers, or any document and get instant answers"
           examples={[
@@ -113,8 +113,8 @@ export const DashboardEmptyState: FC<DashboardEmptyStateProps> = ({ displayName 
 
         <CapabilityCard
           icon={<span className="text-2xl">🤖</span>}
-          iconColor="text-purple-600"
-          iconBg="bg-purple-100"
+          iconColor="text-action"
+          iconBg="bg-action-tint"
           title="Build Custom Bots"
           description="Create your own AI assistant trained on your specific knowledge"
           examples={['Company FAQ bot', 'Product support assistant', 'Personal knowledge base']}

--- a/components/dashboard/QuickActions.tsx
+++ b/components/dashboard/QuickActions.tsx
@@ -94,19 +94,19 @@ interface QuickActionCardProps {
 
 function QuickActionCard({ href, icon, label, color }: QuickActionCardProps) {
   const colorClasses = {
-    blue: 'hover:bg-blue-50 hover:border-blue-200',
+    blue: 'hover:bg-action-tint hover:border-action',
     green: 'hover:bg-green-50 hover:border-green-200',
-    purple: 'hover:bg-purple-50 hover:border-purple-200',
+    purple: 'hover:bg-action-tint hover:border-action',
     orange: 'hover:bg-orange-50 hover:border-orange-200',
-    indigo: 'hover:bg-indigo-50 hover:border-indigo-200',
+    indigo: 'hover:bg-action-tint hover:border-action',
   };
 
   const iconColorClasses = {
-    blue: 'text-blue-600',
+    blue: 'text-action',
     green: 'text-green-600',
-    purple: 'text-purple-600',
+    purple: 'text-action',
     orange: 'text-orange-600',
-    indigo: 'text-indigo-600',
+    indigo: 'text-action',
   };
 
   return (

--- a/components/dashboard/RecentActivity.tsx
+++ b/components/dashboard/RecentActivity.tsx
@@ -22,7 +22,7 @@ export function RecentActivity({ documents, bots, loading }: RecentActivityProps
       <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-lg font-semibold text-gray-900">Recent Documents</h2>
-          <Link href="/documents" className="text-blue-600 hover:text-blue-700 text-sm font-medium">
+          <Link href="/documents" className="text-action hover:text-action text-sm font-medium">
             View all
           </Link>
         </div>
@@ -48,10 +48,7 @@ export function RecentActivity({ documents, bots, loading }: RecentActivityProps
             }
             message="No documents yet"
             action={
-              <Link
-                href="/documents"
-                className="text-blue-600 hover:text-blue-700 text-sm font-medium"
-              >
+              <Link href="/documents" className="text-action hover:text-action text-sm font-medium">
                 Upload your first document
               </Link>
             }
@@ -69,7 +66,7 @@ export function RecentActivity({ documents, bots, loading }: RecentActivityProps
       <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-lg font-semibold text-gray-900">Your Custom Bots</h2>
-          <Link href="/bots/mine" className="text-blue-600 hover:text-blue-700 text-sm font-medium">
+          <Link href="/bots/mine" className="text-action hover:text-action text-sm font-medium">
             Manage bots
           </Link>
         </div>
@@ -83,7 +80,7 @@ export function RecentActivity({ documents, bots, loading }: RecentActivityProps
             action={
               <Link
                 href="/bots/create"
-                className="text-blue-600 hover:text-blue-700 text-sm font-medium"
+                className="text-action hover:text-action text-sm font-medium"
               >
                 Create your first bot
               </Link>

--- a/components/dashboard/StatsGrid.tsx
+++ b/components/dashboard/StatsGrid.tsx
@@ -84,12 +84,12 @@ interface StatCardProps {
 
 function StatCard({ label, value, subtext, icon, color, loading }: StatCardProps) {
   const colorClasses = {
-    blue: 'bg-blue-50 text-blue-600',
+    blue: 'bg-action-tint text-action',
     green: 'bg-green-50 text-green-600',
-    purple: 'bg-purple-50 text-purple-600',
+    purple: 'bg-action-tint text-action',
     yellow: 'bg-yellow-50 text-yellow-600',
     orange: 'bg-orange-50 text-orange-600',
-    indigo: 'bg-indigo-50 text-indigo-600',
+    indigo: 'bg-action-tint text-action',
   };
 
   return (

--- a/components/documents/AddToBotModal.tsx
+++ b/components/documents/AddToBotModal.tsx
@@ -131,7 +131,7 @@ export const AddToBotModal = ({
               <p className="text-gray-600 mb-4">No bots yet</p>
               <Link
                 href="/bots/create"
-                className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 transition-colors text-sm"
+                className="inline-flex items-center px-4 py-2 bg-action text-white rounded-lg font-medium hover:bg-action-hover transition-colors text-sm"
               >
                 Create your first bot
               </Link>
@@ -148,7 +148,7 @@ export const AddToBotModal = ({
                   disabled={importing !== null}
                   className={`w-full flex items-center gap-3 p-3 rounded-lg border transition-colors text-left ${
                     importing === bot.id
-                      ? 'bg-blue-50 border-blue-300'
+                      ? 'bg-action-tint border-edge'
                       : 'bg-gray-50 border-gray-200 hover:bg-gray-100 hover:border-gray-300'
                   } disabled:opacity-60 disabled:cursor-not-allowed`}
                 >
@@ -160,7 +160,7 @@ export const AddToBotModal = ({
                     </p>
                   </div>
                   {importing === bot.id ? (
-                    <div className="w-5 h-5 border-2 border-blue-600 border-t-transparent rounded-full animate-spin flex-shrink-0" />
+                    <div className="w-5 h-5 border-2 border-edge border-t-transparent rounded-full animate-spin flex-shrink-0" />
                   ) : (
                     <svg
                       className="w-5 h-5 text-gray-400 flex-shrink-0"
@@ -184,10 +184,7 @@ export const AddToBotModal = ({
 
         {/* Footer */}
         <div className="flex items-center justify-between p-4 border-t border-gray-200 bg-gray-50">
-          <Link
-            href="/bots/create"
-            className="text-sm text-blue-600 hover:text-blue-700 font-medium"
-          >
+          <Link href="/bots/create" className="text-sm text-action hover:text-action font-medium">
             + Create new bot
           </Link>
           <button

--- a/components/documents/CategorySelector.tsx
+++ b/components/documents/CategorySelector.tsx
@@ -74,7 +74,7 @@ export const CategorySelector: FC<CategorySelectorProps> = ({
               key={cat.value}
               onClick={() => handleSelect(cat.value)}
               className={`w-full text-left px-3 py-2 text-sm hover:bg-gray-50 flex items-center gap-2 ${
-                cat.value === category ? 'bg-blue-50 text-blue-700' : 'text-gray-700'
+                cat.value === category ? 'bg-action-tint text-action' : 'text-gray-700'
               }`}
             >
               <span>{cat.emoji}</span>

--- a/components/documents/ChatMessageList.tsx
+++ b/components/documents/ChatMessageList.tsx
@@ -33,7 +33,7 @@ export const ChatMessageList = ({
           <div
             key={msg.id || i}
             className={`p-4 rounded-lg ${
-              msg.role === 'user' ? 'bg-blue-100 ml-8' : 'bg-gray-100 mr-8'
+              msg.role === 'user' ? 'bg-action-tint ml-8' : 'bg-gray-100 mr-8'
             }`}
           >
             <p className="text-gray-900 whitespace-pre-wrap">{msg.content}</p>

--- a/components/documents/DocumentChatPanel.tsx
+++ b/components/documents/DocumentChatPanel.tsx
@@ -46,7 +46,7 @@ export const DocumentChatPanel = ({
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-lg font-semibold text-gray-900">Chat with Documents</h2>
           {selectedDocId && (
-            <span className="text-sm text-blue-600">
+            <span className="text-sm text-action">
               Filtering: {documents.find((d) => d.id === selectedDocId)?.name}
             </span>
           )}
@@ -88,12 +88,12 @@ export const DocumentChatPanel = ({
                 onChange={(e) => setChatInput(e.target.value)}
                 placeholder="Ask a question..."
                 disabled={chatLoading}
-                className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-action disabled:opacity-50"
               />
               <button
                 type="submit"
                 disabled={chatLoading || !chatInput.trim()}
-                className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-4 py-2 bg-action text-white rounded-lg hover:bg-action-hover disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 Send
               </button>

--- a/components/documents/DocumentListPanel.tsx
+++ b/components/documents/DocumentListPanel.tsx
@@ -111,7 +111,7 @@ export const DocumentListPanel = ({
             <div
               key={doc.id}
               className={`p-4 border rounded-lg ${
-                selectedDocId === doc.id ? 'border-blue-500 bg-blue-50' : 'border-gray-200'
+                selectedDocId === doc.id ? 'border-edge bg-action-tint' : 'border-gray-200'
               }`}
             >
               <div className="flex items-start justify-between">
@@ -133,7 +133,7 @@ export const DocumentListPanel = ({
                     <button
                       onClick={() => handleProcess(doc.id)}
                       disabled={processing === doc.id}
-                      className="px-3 py-1 text-sm bg-blue-100 text-blue-700 rounded hover:bg-blue-200 disabled:opacity-50"
+                      className="px-3 py-1 text-sm bg-surface text-action rounded hover:bg-action-tint disabled:opacity-50"
                     >
                       {processing === doc.id ? 'Processing...' : 'Process'}
                     </button>
@@ -143,7 +143,7 @@ export const DocumentListPanel = ({
                       {onOpenAddToBot && (
                         <button
                           onClick={() => onOpenAddToBot(doc)}
-                          className="px-3 py-1 text-sm bg-purple-100 text-purple-700 rounded hover:bg-purple-200"
+                          className="px-3 py-1 text-sm bg-surface text-action rounded hover:bg-action-tint"
                           title="Add to Bot"
                         >
                           + Bot
@@ -153,7 +153,7 @@ export const DocumentListPanel = ({
                         onClick={() => onSelectDoc(selectedDocId === doc.id ? null : doc.id)}
                         className={`px-3 py-1 text-sm rounded ${
                           selectedDocId === doc.id
-                            ? 'bg-blue-600 text-white'
+                            ? 'bg-action text-white'
                             : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                         }`}
                       >

--- a/components/documents/DocumentUploadButton.tsx
+++ b/components/documents/DocumentUploadButton.tsx
@@ -57,7 +57,7 @@ export const DocumentUploadButton = ({ onUploaded }: DocumentUploadButtonProps) 
       />
       <label
         htmlFor="file-upload"
-        className={`inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 cursor-pointer transition-colors ${
+        className={`inline-flex items-center px-4 py-2 bg-action text-white rounded-lg font-medium hover:bg-action-hover cursor-pointer transition-colors ${
           uploading ? 'opacity-50 cursor-not-allowed' : ''
         }`}
       >

--- a/components/infrastructure/StorageCard.tsx
+++ b/components/infrastructure/StorageCard.tsx
@@ -24,7 +24,7 @@ export const StorageCard: FC<StorageCardProps> = ({ option, isActive = false, on
   const isAvailable = status === 'available';
   const isDisabled = !isAvailable;
 
-  const selectedRing = isActive ? 'ring-2 ring-blue-500 ring-offset-2' : '';
+  const selectedRing = isActive ? 'ring-2 ring-action ring-offset-2' : '';
   const hoverClasses = isDisabled
     ? 'cursor-not-allowed opacity-60'
     : 'cursor-pointer hover:shadow-lg hover:border-gray-200 hover:-translate-y-0.5';
@@ -38,7 +38,7 @@ export const StorageCard: FC<StorageCardProps> = ({ option, isActive = false, on
     >
       {/* Active indicator */}
       {isActive && (
-        <div className="absolute top-2 right-2 bg-blue-500 rounded-full p-1">
+        <div className="absolute top-2 right-2 bg-action rounded-full p-1">
           <svg className="w-2.5 h-2.5 text-white" fill="currentColor" viewBox="0 0 20 20">
             <path
               fillRule="evenodd"

--- a/components/knowledge/GuideCard.tsx
+++ b/components/knowledge/GuideCard.tsx
@@ -18,12 +18,12 @@ export function GuideCard({ guide }: GuideCardProps) {
   return (
     <Link
       href={`/knowledge/guides/${guide.slug}`}
-      className="group block rounded-xl border border-gray-200 bg-white p-6 transition-all hover:border-blue-300 hover:shadow-lg"
+      className="group block rounded-xl border border-gray-200 bg-white p-6 transition-all hover:border-action hover:shadow-lg"
     >
       {/* Header with icon and difficulty */}
       <div className="flex items-start justify-between mb-4">
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-gray-100 text-xl group-hover:bg-blue-50 transition-colors">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-gray-100 text-xl group-hover:bg-action-tint transition-colors">
             {guide.icon || category.icon}
           </div>
           <div>
@@ -36,7 +36,7 @@ export function GuideCard({ guide }: GuideCardProps) {
       </div>
 
       {/* Title */}
-      <h3 className="text-lg font-semibold text-gray-900 group-hover:text-blue-600 transition-colors mb-2">
+      <h3 className="text-lg font-semibold text-gray-900 group-hover:text-action transition-colors mb-2">
         {guide.title}
       </h3>
 
@@ -57,7 +57,7 @@ export function GuideCard({ guide }: GuideCardProps) {
             </span>
           )}
         </div>
-        <span className="text-blue-600 font-medium group-hover:underline">Read guide</span>
+        <span className="text-action font-medium group-hover:underline">Read guide</span>
       </div>
 
       {/* Tags */}

--- a/components/knowledge/TableOfContents.tsx
+++ b/components/knowledge/TableOfContents.tsx
@@ -67,7 +67,7 @@ export function TableOfContents({ items }: TableOfContentsProps) {
                 item.level === 3 ? 'pl-4' : ''
               } ${item.level === 4 ? 'pl-8' : ''} ${
                 activeId === item.id
-                  ? 'text-blue-600 font-medium'
+                  ? 'text-action font-medium'
                   : 'text-gray-600 hover:text-gray-900'
               }`}
             >

--- a/components/navigation/AuthNav.tsx
+++ b/components/navigation/AuthNav.tsx
@@ -44,7 +44,7 @@ export function AuthNav() {
       <div className="flex items-center gap-3">
         <Link
           href="/auth/signin"
-          className="text-sm font-medium text-gray-700 hover:text-blue-600 transition-colors"
+          className="text-sm font-medium text-gray-700 hover:text-action transition-colors"
         >
           Login
         </Link>
@@ -68,7 +68,7 @@ export function AuthNav() {
     <div className="relative" ref={dropdownRef}>
       <button
         onClick={() => setDropdownOpen(!dropdownOpen)}
-        className="flex items-center gap-2 text-sm font-medium text-gray-700 hover:text-blue-600 transition-colors"
+        className="flex items-center gap-2 text-sm font-medium text-gray-700 hover:text-action transition-colors"
       >
         <UserAvatar email={user.email} initial={displayName?.[0]} avatarUrl={avatarUrl} size="sm" />
         <ChevronIcon open={dropdownOpen} className="w-4 h-4" />

--- a/components/navigation/MegaMenuItem.tsx
+++ b/components/navigation/MegaMenuItem.tsx
@@ -17,7 +17,7 @@ export function MegaMenuItem({ item, onNavigate }: MegaMenuItemProps) {
     <Link
       href={item.path}
       onClick={onNavigate}
-      className="group flex items-start gap-3 rounded-lg p-3 transition-all hover:bg-gradient-to-r hover:from-gray-50 hover:to-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+      className="group flex items-start gap-3 rounded-lg p-3 transition-all hover:bg-gradient-to-r hover:from-gray-50 hover:to-action-tint focus:outline-none focus:ring-2 focus:ring-action focus:ring-offset-2"
     >
       {/* Icon */}
       {item.icon && (
@@ -28,7 +28,7 @@ export function MegaMenuItem({ item, onNavigate }: MegaMenuItemProps) {
 
       {/* Content */}
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">
+        <p className="text-sm font-semibold text-gray-900 group-hover:text-action transition-colors">
           {item.label}
         </p>
         {item.description && (

--- a/components/navigation/MegaMenuPanel.tsx
+++ b/components/navigation/MegaMenuPanel.tsx
@@ -28,7 +28,7 @@ export function MegaMenuPanel({ items, config, onNavigate }: MegaMenuPanelProps)
       {/* Optional Header */}
       {config?.header && (
         <div
-          className={`border-b border-gray-100 px-6 py-4 ${config.header.gradient ?? 'bg-gradient-to-r from-blue-50 to-cyan-50'}`}
+          className={`border-b border-gray-100 px-6 py-4 ${config.header.gradient ?? 'bg-action-tint'}`}
         >
           <h3 className="text-sm font-semibold text-gray-900">{config.header.title}</h3>
           {config.header.subtitle && (
@@ -50,7 +50,7 @@ export function MegaMenuPanel({ items, config, onNavigate }: MegaMenuPanelProps)
           <Link
             href={config.footer.href}
             onClick={onNavigate}
-            className="group flex items-center justify-between text-sm font-medium text-gray-900 hover:text-blue-600 transition-colors"
+            className="group flex items-center justify-between text-sm font-medium text-gray-900 hover:text-action transition-colors"
           >
             <span>{config.footer.label}</span>
             <svg

--- a/components/navigation/NavItem.tsx
+++ b/components/navigation/NavItem.tsx
@@ -48,8 +48,8 @@ export function NavItem({ item, isActive, onNavigate }: NavItemProps) {
       <Link
         href={item.path}
         className={`text-sm font-medium transition-colors ${
-          isActive ? 'text-blue-600' : 'text-gray-600'
-        } hover:text-blue-600`}
+          isActive ? 'text-action' : 'text-gray-600'
+        } hover:text-action`}
       >
         {item.label}
       </Link>
@@ -64,8 +64,8 @@ export function NavItem({ item, isActive, onNavigate }: NavItemProps) {
           <Popover.Button
             ref={buttonRef}
             className={`group inline-flex items-center gap-1 text-sm font-medium transition-colors focus:outline-none ${
-              open || isActive ? 'text-blue-600' : 'text-gray-600'
-            } hover:text-blue-600`}
+              open || isActive ? 'text-action' : 'text-gray-600'
+            } hover:text-action`}
           >
             {item.label}
             <ChevronIcon open={open} className="h-4 w-4" />

--- a/components/navigation/SiteMenuDropdown.tsx
+++ b/components/navigation/SiteMenuDropdown.tsx
@@ -72,9 +72,9 @@ export function SiteMenuDropdown({ className = '' }: SiteMenuDropdownProps) {
               <Popover.Panel static style={getDropdownStyle()} className="w-56">
                 <div className="overflow-hidden rounded-xl bg-white shadow-xl ring-1 ring-black ring-opacity-5 border border-gray-100">
                   {/* Header */}
-                  <div className="border-b border-gray-100 bg-gradient-to-r from-blue-50 to-purple-50 px-4 py-3">
+                  <div className="border-b border-gray-100 bg-action-tint px-4 py-3">
                     <Link href="/" onClick={() => close()} className="flex items-center gap-2">
-                      <div className="bg-gradient-to-r from-blue-600 to-purple-600 text-white font-bold text-sm px-2 py-1 rounded">
+                      <div className="bg-action text-white font-bold text-sm px-2 py-1 rounded">
                         B
                       </div>
                       <span className="text-sm font-semibold text-gray-900">Botsmann</span>
@@ -117,7 +117,7 @@ export function SiteMenuDropdown({ className = '' }: SiteMenuDropdownProps) {
                     <Link
                       href="/contact"
                       onClick={() => close()}
-                      className="flex items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-blue-600 to-purple-600 px-4 py-2 text-sm font-medium text-white hover:opacity-90 transition-opacity"
+                      className="flex items-center justify-center gap-2 rounded-lg bg-action px-4 py-2 text-sm font-medium text-white hover:opacity-90 transition-opacity"
                     >
                       Contact Us
                     </Link>

--- a/components/onboarding/OnboardingChecklist.tsx
+++ b/components/onboarding/OnboardingChecklist.tsx
@@ -145,13 +145,13 @@ export const OnboardingChecklist = ({
     <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
       {/* Header */}
       <div
-        className="flex items-center justify-between p-4 bg-gradient-to-r from-blue-50 to-indigo-50 border-b border-gray-200 cursor-pointer"
+        className="flex items-center justify-between p-4 bg-action-tint border-b border-gray-200 cursor-pointer"
         onClick={() => setIsMinimized(!isMinimized)}
       >
         <div className="flex items-center gap-3">
-          <div className="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center">
+          <div className="w-10 h-10 bg-action-tint rounded-full flex items-center justify-center">
             <svg
-              className="w-5 h-5 text-blue-600"
+              className="w-5 h-5 text-action"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -177,7 +177,7 @@ export const OnboardingChecklist = ({
           <div className="hidden sm:flex items-center gap-2">
             <div className="w-24 h-2 bg-gray-200 rounded-full overflow-hidden">
               <div
-                className="h-full bg-blue-500 rounded-full transition-all duration-300"
+                className="h-full bg-action rounded-full transition-all duration-300"
                 style={{ width: `${progress}%` }}
               />
             </div>

--- a/components/onboarding/OnboardingStep.tsx
+++ b/components/onboarding/OnboardingStep.tsx
@@ -36,7 +36,7 @@ export const OnboardingStep = ({
       {/* Step Number / Checkmark */}
       <div
         className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium ${
-          completed ? 'bg-green-500 text-white' : 'bg-blue-100 text-blue-700'
+          completed ? 'bg-green-500 text-white' : 'bg-action-tint text-action'
         }`}
       >
         {completed ? (
@@ -71,7 +71,7 @@ export const OnboardingStep = ({
       {!completed && (
         <div className="flex-shrink-0">
           {href ? (
-            <span className="text-blue-600 text-sm font-medium">Go &rarr;</span>
+            <span className="text-action text-sm font-medium">Go &rarr;</span>
           ) : onComplete ? (
             <button
               onClick={(e) => {
@@ -79,7 +79,7 @@ export const OnboardingStep = ({
                 e.stopPropagation();
                 onComplete();
               }}
-              className="text-blue-600 text-sm font-medium hover:text-blue-700"
+              className="text-action text-sm font-medium hover:text-action"
             >
               Mark done
             </button>

--- a/components/shared/BotFeatureCard.tsx
+++ b/components/shared/BotFeatureCard.tsx
@@ -41,7 +41,7 @@ interface BotFeatureCardProps {
  *     icon: '🔐',
  *     title: 'Secure',
  *     description: 'End-to-end encryption',
- *     color: 'from-purple-500 to-pink-500'
+ *     color: 'from-action to-action-hover'
  *   }}
  *   variant="gradient"
  * />
@@ -74,7 +74,7 @@ export const BotFeatureCard: FC<BotFeatureCardProps> = ({
     gradient: `${baseClasses} border-2 border-gray-100 hover:border-gray-200 hover:shadow-xl group`,
     simple: `${baseClasses} border ${
       isSelected
-        ? 'border-blue-500 shadow-md'
+        ? 'border-action shadow-md'
         : 'border-gray-200 shadow-sm hover:shadow-md hover:border-gray-300'
     }`,
   };
@@ -163,7 +163,7 @@ export const BotFeatureGrid: FC<BotFeatureGridProps> = ({
       {header && (
         <div className="text-center mb-12">
           {header.badge && (
-            <div className="inline-flex items-center px-4 py-2 bg-gradient-to-r from-blue-50 to-cyan-50 text-blue-700 rounded-full text-sm font-medium mb-6">
+            <div className="inline-flex items-center px-4 py-2 bg-action-tint text-action rounded-full text-sm font-medium mb-6">
               {header.badge.emoji && <span className="mr-2">{header.badge.emoji}</span>}
               {header.badge.text}
             </div>

--- a/components/shared/BotNotFoundFallback.tsx
+++ b/components/shared/BotNotFoundFallback.tsx
@@ -17,7 +17,7 @@ export const BotNotFoundFallback: FC<BotNotFoundFallbackProps> = ({ botName = 'B
         <p className="text-gray-600 mb-6">The bot configuration could not be loaded.</p>
         <Link
           href="/bots"
-          className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+          className="inline-flex items-center px-4 py-2 bg-action text-white rounded-md hover:bg-action-hover transition-colors"
         >
           <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path

--- a/components/shared/LoadingSpinner.tsx
+++ b/components/shared/LoadingSpinner.tsx
@@ -27,7 +27,7 @@ export function LoadingSpinner({
 }: LoadingSpinnerProps) {
   const spinner = (
     <div
-      className={`animate-spin rounded-full border-b-2 border-blue-600 ${sizeClasses[size]} ${className || ''}`}
+      className={`animate-spin rounded-full border-b-2 border-action ${sizeClasses[size]} ${className || ''}`}
     />
   );
 

--- a/components/shared/ProfessionalDemo.tsx
+++ b/components/shared/ProfessionalDemo.tsx
@@ -241,7 +241,7 @@ export const ProfessionalDemo: FC<ProfessionalDemoProps> = ({ professional }) =>
                 <button
                   key={index}
                   onClick={() => handleStarterQuestion(question)}
-                  className={`text-sm bg-white border border-gray-200 px-3 py-1.5 rounded-full ${ACCENT_STARTER_HOVER_CLASSES[professional.accentColor] || 'hover:border-blue-300 hover:bg-blue-50'} transition-colors`}
+                  className={`text-sm bg-white border border-gray-200 px-3 py-1.5 rounded-full ${ACCENT_STARTER_HOVER_CLASSES[professional.accentColor] || 'hover:border-action hover:bg-action-tint'} transition-colors`}
                 >
                   {question}
                 </button>
@@ -260,7 +260,7 @@ export const ProfessionalDemo: FC<ProfessionalDemoProps> = ({ professional }) =>
               onChange={(e) => setInput(e.target.value)}
               placeholder={`Message ${professional.name}...`}
               disabled={isLoading}
-              className={`flex-1 px-4 py-3 rounded-xl border-2 border-gray-200 ${ACCENT_FOCUS_BORDER_CLASSES[professional.accentColor] || 'focus:border-blue-500'} focus:ring-0 transition-colors disabled:opacity-50`}
+              className={`flex-1 px-4 py-3 rounded-xl border-2 border-gray-200 ${ACCENT_FOCUS_BORDER_CLASSES[professional.accentColor] || 'focus:border-action'} focus:ring-0 transition-colors disabled:opacity-50`}
             />
             <button
               type="submit"

--- a/components/shared/UserAvatar.tsx
+++ b/components/shared/UserAvatar.tsx
@@ -54,7 +54,7 @@ export const UserAvatar: FC<UserAvatarProps> = ({
   // Fallback to initial with gradient background
   return (
     <div
-      className={`${sizeClass} rounded-full bg-gradient-to-r from-blue-500 to-purple-500 flex items-center justify-center text-white font-bold ${className}`}
+      className={`${sizeClass} rounded-full bg-action flex items-center justify-center text-white font-bold ${className}`}
     >
       {displayInitial}
     </div>

--- a/components/shared/demo/DemoFileUpload.tsx
+++ b/components/shared/demo/DemoFileUpload.tsx
@@ -19,7 +19,7 @@ function getStatusIcon(status: UploadedFile['status']) {
   switch (status) {
     case 'uploading':
       return (
-        <svg className="w-4 h-4 animate-spin text-blue-500" fill="none" viewBox="0 0 24 24">
+        <svg className="w-4 h-4 animate-spin text-action" fill="none" viewBox="0 0 24 24">
           <circle
             className="opacity-25"
             cx="12"

--- a/components/shared/quick-create/TemplatePicker.tsx
+++ b/components/shared/quick-create/TemplatePicker.tsx
@@ -63,9 +63,7 @@ export const TemplatePicker: FC<TemplatePickerProps> = ({ onSelect }) => {
       {/* Title */}
       <div className="text-center">
         <h1 className="text-4xl md:text-5xl font-bold mb-4">
-          <span className="bg-gradient-to-r from-purple-600 via-pink-600 to-blue-600 bg-clip-text text-transparent">
-            Who Do You Want to Create?
-          </span>
+          <span className="text-action">Who Do You Want to Create?</span>
         </h1>
         <p className="text-lg text-gray-600 max-w-2xl mx-auto">
           Pick a template and start chatting in under 60 seconds

--- a/components/try/TryChatPanel.tsx
+++ b/components/try/TryChatPanel.tsx
@@ -79,7 +79,7 @@ export const TryChatPanel = ({ documents, onError }: TryChatPanelProps) => {
   return (
     <div className="bg-white rounded-2xl shadow-lg border border-gray-100 overflow-hidden flex flex-col h-[calc(100vh-16rem)] min-h-[400px] max-h-[600px] md:max-h-none md:h-[600px]">
       {/* Chat Header */}
-      <div className="px-6 py-4 border-b border-gray-100 bg-gradient-to-r from-blue-50 to-purple-50">
+      <div className="px-6 py-4 border-b border-gray-100 bg-action-tint">
         <h2 className="text-lg font-bold text-gray-900">Chat</h2>
         <p className="text-sm text-gray-600">Ask questions about your documents</p>
       </div>
@@ -89,9 +89,9 @@ export const TryChatPanel = ({ documents, onError }: TryChatPanelProps) => {
         {documents.length === 0 ? (
           <div className="flex items-center justify-center h-full text-gray-500 text-center">
             <div className="max-w-sm">
-              <div className="w-20 h-20 mx-auto mb-4 bg-gradient-to-br from-blue-100 to-purple-100 rounded-2xl flex items-center justify-center">
+              <div className="w-20 h-20 mx-auto mb-4 bg-action-tint rounded-2xl flex items-center justify-center">
                 <svg
-                  className="w-10 h-10 text-blue-500"
+                  className="w-10 h-10 text-action"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -119,7 +119,7 @@ export const TryChatPanel = ({ documents, onError }: TryChatPanelProps) => {
         ) : messages.length === 0 ? (
           <div className="flex items-center justify-center h-full text-gray-500 text-center">
             <div className="max-w-md">
-              <div className="w-16 h-16 mx-auto mb-4 bg-gradient-to-br from-green-100 to-blue-100 rounded-full flex items-center justify-center">
+              <div className="w-16 h-16 mx-auto mb-4 bg-gradient-to-br from-green-100 to-action-tint rounded-full flex items-center justify-center">
                 <svg
                   className="w-8 h-8 text-green-500"
                   fill="none"
@@ -141,25 +141,25 @@ export const TryChatPanel = ({ documents, onError }: TryChatPanelProps) => {
               <div className="flex flex-wrap justify-center gap-2">
                 <button
                   onClick={() => setInput('What is this document about?')}
-                  className="px-3 py-1.5 text-sm bg-blue-50 text-blue-700 rounded-full hover:bg-blue-100 transition-colors"
+                  className="px-3 py-1.5 text-sm bg-surface text-action rounded-full hover:bg-action-tint transition-colors"
                 >
                   What is this document about?
                 </button>
                 <button
                   onClick={() => setInput('Summarize the key points')}
-                  className="px-3 py-1.5 text-sm bg-blue-50 text-blue-700 rounded-full hover:bg-blue-100 transition-colors"
+                  className="px-3 py-1.5 text-sm bg-surface text-action rounded-full hover:bg-action-tint transition-colors"
                 >
                   Summarize the key points
                 </button>
                 <button
                   onClick={() => setInput('What are the main conclusions?')}
-                  className="px-3 py-1.5 text-sm bg-blue-50 text-blue-700 rounded-full hover:bg-blue-100 transition-colors"
+                  className="px-3 py-1.5 text-sm bg-surface text-action rounded-full hover:bg-action-tint transition-colors"
                 >
                   What are the main conclusions?
                 </button>
                 <button
                   onClick={() => setInput('List any action items or recommendations')}
-                  className="px-3 py-1.5 text-sm bg-blue-50 text-blue-700 rounded-full hover:bg-blue-100 transition-colors"
+                  className="px-3 py-1.5 text-sm bg-surface text-action rounded-full hover:bg-action-tint transition-colors"
                 >
                   List action items
                 </button>
@@ -174,7 +174,7 @@ export const TryChatPanel = ({ documents, onError }: TryChatPanelProps) => {
             >
               <div
                 className={`max-w-[85%] rounded-2xl px-4 py-3 ${
-                  msg.role === 'user' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-900'
+                  msg.role === 'user' ? 'bg-action text-white' : 'bg-gray-100 text-gray-900'
                 }`}
               >
                 <p className="whitespace-pre-wrap">{msg.content}</p>
@@ -246,12 +246,12 @@ export const TryChatPanel = ({ documents, onError }: TryChatPanelProps) => {
                 : 'Ask a question about your documents...'
             }
             disabled={isLoading || documents.length === 0}
-            className="flex-1 px-4 py-3 rounded-xl border border-gray-200 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 transition-all disabled:opacity-50 disabled:bg-gray-50"
+            className="flex-1 px-4 py-3 rounded-xl border border-gray-200 focus:border-action focus:ring-2 focus:ring-action transition-all disabled:opacity-50 disabled:bg-gray-50"
           />
           <button
             type="submit"
             disabled={isLoading || !input.trim() || documents.length === 0}
-            className="px-6 py-3 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
+            className="px-6 py-3 bg-action text-white rounded-xl font-medium hover:bg-action-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
             title="Send (Cmd+Enter)"
           >
             Send

--- a/components/try/TryDocumentsPanel.tsx
+++ b/components/try/TryDocumentsPanel.tsx
@@ -132,12 +132,12 @@ export const TryDocumentsPanel = ({
           htmlFor="file-upload"
           className={`flex flex-col items-center justify-center w-full h-32 border-2 border-dashed rounded-xl cursor-pointer transition-colors ${
             uploading
-              ? 'border-blue-300 bg-blue-50'
-              : 'border-gray-300 hover:border-blue-400 hover:bg-blue-50'
+              ? 'border-edge bg-action-tint'
+              : 'border-gray-300 hover:border-action hover:bg-action-tint'
           }`}
         >
           {uploading ? (
-            <div className="flex items-center gap-2 text-blue-600">
+            <div className="flex items-center gap-2 text-action">
               <svg className="animate-spin h-5 w-5" fill="none" viewBox="0 0 24 24">
                 <circle
                   className="opacity-25"

--- a/tests/__tests__/lib/design-tokens.test.ts
+++ b/tests/__tests__/lib/design-tokens.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Guard: the brand palette lives in app/globals.css, and nowhere else.
+ *
+ * globals.css defines the identity -- editorial ink, one ochre accent -- and
+ * says so plainly: "No generic AI gradient blue/purple." The product ignored it
+ * anyway. A single viewport of a bot page once showed a blue logo, a blue nav
+ * button and an ochre CTA at the same time, because four different files each
+ * believed they owned colour.
+ *
+ * Components may only use semantic classes (bg-action, text-ink, border-edge...)
+ * which tailwind.config maps to the CSS custom properties. Raw palette classes
+ * are how the drift started, so they are refused here.
+ */
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative, sep } from 'path';
+
+const ROOT = process.cwd();
+
+/** Raw Tailwind palette hues that would compete with the brand accent. */
+const BRAND_HUES = 'blue|purple|indigo|violet|cyan|pink|fuchsia|sky|teal';
+const RAW_CLASS = new RegExp(
+  `\\b(?:from|via|to|bg|text|border|ring|divide|outline|shadow|accent|decoration)-(?:${BRAND_HUES})-\\d{2,3}\\b`,
+  'g',
+);
+
+/**
+ * Surfaces where a user picks their own bot's colour. custom_bots.accent_color
+ * is a real column with a CHECK constraint -- that is user data, not a design
+ * token, so the per-colour class maps legitimately live here.
+ */
+const CUSTOM_BOT_SURFACES = [
+  join('app', 'bots', 'custom'),
+  join('app', 'bots', 'mine'),
+  join('app', 'bots', 'create'),
+  join('components', 'bot-builder'),
+  join('components', 'shared', 'quick-create'),
+  join('lib', 'config', 'colors.ts'),
+];
+
+/** Semantic status colours are a separate scale from the brand accent. */
+const SEMANTIC_FILES = [join('components', 'knowledge', 'Callout.tsx')];
+
+function tsxFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry.startsWith('.')) continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...tsxFiles(full));
+    else if (entry.endsWith('.tsx') || entry.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+function isAllowed(rel: string): boolean {
+  const norm = rel.split('/').join(sep);
+  return (
+    CUSTOM_BOT_SURFACES.some((p) => norm.startsWith(p)) || SEMANTIC_FILES.some((p) => norm === p)
+  );
+}
+
+describe('design tokens', () => {
+  const files = [...tsxFiles(join(ROOT, 'app')), ...tsxFiles(join(ROOT, 'components'))];
+
+  it('scans a meaningful number of files', () => {
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  it('no component uses a raw brand-palette class', () => {
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const rel = relative(ROOT, file);
+      if (isAllowed(rel)) continue;
+
+      const matches = readFileSync(file, 'utf-8').match(RAW_CLASS);
+      if (matches) offenders.push(`${rel}: ${[...new Set(matches)].join(', ')}`);
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('no gradient is clipped to text (the identity is carried by type, not gradients)', () => {
+    const offenders = files
+      .filter((f) => !isAllowed(relative(ROOT, f)))
+      .filter((f) => readFileSync(f, 'utf-8').includes('bg-clip-text'))
+      .map((f) => relative(ROOT, f));
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
#144 put the bot pages on the brand. This does the other **60 files**, so the whole product reads as one thing — and adds the guard that keeps it that way.

## What changed

**~410 raw palette classes → semantic tokens**, across the public marketing surface (`/try`, `/enterprise`, `/about`, `/knowledge`, `/personal`, `/professionals`, `/bots`, blog, navigation) and the app internals (dashboard, documents, chat, conversations, onboarding, auth, settings, profile).

**Gradient text is gone.** Fifteen headings were `bg-gradient-to-r from-X to-Y bg-clip-text text-transparent`; they're now solid `text-ink` or `text-action`. `globals.css` says the identity is carried by typography — a serif display doesn't need a gradient to do that.

**The `B` mark was still a blue/purple gradient in `BotNavigation`'s *mobile* menu.** #144 only fixed the desktop header. Both now render the shared `<Logo>`.

## Three defects I introduced mid-sweep and corrected

Caught by reading the diff rather than trusting the regex:

1. **Degenerate gradients** — `from-action-tint to-action-tint` (same colour both ends) collapsed to solid.
2. **Dead hovers** — `hover:bg-action-tint` on a `bg-action-tint` base; rebased to `bg-surface` + `hover:bg-action-tint`.
3. **A regex bug** — `to-action\b` matched the *prefix* of `to-action-hover` (the hyphen is a word boundary), so a gradient collapse left a stray `bg-action-hover` as a **base** background in 11 places. Those want the primary, not the hover shade.

## Deliberately NOT changed

- **`components/knowledge/Callout.tsx`** — its blue is the `info` half of an info/warning/error triad. Semantic status colour is a separate scale from the brand accent, and `warning` is amber, so ochre-ing `info` would make the two nearly indistinguishable.
- **The custom-bot surfaces** — `custom_bots.accent_color` is a real column with a `CHECK` constraint and the owner picks it. User data, not a design token.

## Never-twice

`tests/__tests__/lib/design-tokens.test.ts` refuses any raw brand-palette class, and any `bg-clip-text`, outside those two documented exceptions. Mutation-verified — swap one token back to `bg-blue-600` and it fails and names the file.

**No allowlist debt**: every other file was swept rather than excused.

## Verify

`format:check`, `lint`, `typecheck`, **256 tests**, `build` — all green. Twelve pages smoke-tested and checked visually against a local production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVwg8DKHQktxJuHeLM3xpG