### PR TITLE
docs(ci): the sweep lives in bitbaum/fleet, not dotfiles

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,7 +1,7 @@
 # Auto-merge — nobody is in the merge loop.
 #
 # Green, ready PRs merge themselves and deploy themselves. The policy lives in
-# ONE place for the whole fleet — bitbaum/dotfiles,
+# ONE place for the whole fleet — bitbaum/fleet,
 # scripts/ci/auto-merge-sweep.sh — and this file only says "run it, with these
 # settings".
 #


### PR DESCRIPTION
The `uses:` line here is already correct. What was stale is the prose beside it.

It told the reader that the sweep policy lives in `bitbaum/dotfiles`, at `scripts/ci/auto-merge-sweep.sh`, and to **"change it THERE"**. That file no longer exists in dotfiles — the sweep moved to **`bitbaum/fleet`** on 2026-08-28, because a repo holding someone's `.bashrc` and editor config is not where a fleet's deploy policy belongs.

**A comment that misroutes a fix is worse than a missing one.** It sends the next person — or the next agent, since `CLAUDE.md` carried the same sentence — to edit a repo where the change would reach nobody. That is precisely the failure the shared sweep was built to prevent, reintroduced through documentation instead of code.

Three flavours of the same staleness are corrected across the fleet:

- **16 `auto-merge.yml` callers** — the "ONE place for the whole fleet" comment
- **`fleetcrown/CLAUDE.md`** — the shipping section, which is the instruction file agents read before touching CI
- **3 `ci.yml` golden-floor pointers** (`printcraft`, `solon`, `limitkit`) — the templates moved to `bitbaum/fleet` as well, and `limitkit` still named the retired `catomean` owner on top of that

No behaviour changes: not one `uses:`, input, or permission is touched. This is the documentation catching up with a migration that already happened, verified across all 38 org repos — 156 workflow files read, 0 unreadable, 0 remaining live `uses:` references to dotfiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvjGNAS9CMfEGNW26tUR4P
