### PR TITLE
fix(health): liveness must not fail on something a restart cannot fix

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,20 +1,26 @@
+import { type NextRequest } from 'next/server';
 import { supabase, isSupabaseConfigured } from '@/lib/supabase';
 import { jsonSuccess, jsonServiceUnavailable } from '@/lib/api';
 import { logger } from '@/lib/logger';
 import { getLLMHealth } from '@/lib/llm-health';
 
 /**
- * Health check.
+ * Health check, in two flavours.
  *
- * Reports the database AND the LLM chain. It used to report only the database,
- * so on 2026-08-28 it answered "healthy" while every AI feature on the site was
- * failing on an invalid Groq key -- the product's core capability was dead and
- * nothing that watches this endpoint could tell.
+ * Default (liveness): is this process serving and can it reach its database?
+ * Answers 200 even when the LLM chain is down, because restarting the app does
+ * not fix an expired API key -- failing liveness on it would just get a healthy
+ * process killed, and would fail deploy gates on a problem no deploy caused.
  *
- * LLM state comes from what the chat routes actually observed, so it costs
- * nothing here and reflects real traffic rather than a synthetic probe.
+ * ?strict=1 (readiness): is the PRODUCT working? 503 once the LLM chain is
+ * consistently failing. Point alerting here.
+ *
+ * Either way the body carries the real state. This endpoint used to report
+ * only the database, so on 2026-08-28 it said "healthy" while every AI feature
+ * on the site was failing on an invalid Groq key.
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
+  const strict = request.nextUrl.searchParams.get('strict') === '1';
   const llm = getLLMHealth();
 
   try {
@@ -28,20 +34,17 @@ export async function GET() {
       throw error;
     }
 
-    // The database being up is not the same as the product working.
-    if (llm.status === 'down') {
-      logger.error('Health check: LLM chain is down', { lastError: llm.lastError });
+    // 'unknown' means nothing has exercised the chain since this process
+    // started. That is not evidence of a problem, so it is not degraded.
+    const status =
+      llm.status === 'down' ? 'down' : llm.status === 'degraded' ? 'degraded' : 'healthy';
+
+    if (strict && llm.status === 'down') {
+      logger.error('Health check (strict): LLM chain is down', { lastError: llm.lastError });
       return jsonServiceUnavailable('AI provider unavailable');
     }
 
-    return jsonSuccess(
-      {
-        status: llm.status === 'degraded' ? 'degraded' : 'healthy',
-        database: 'connected',
-        llm,
-      },
-      { cache: 'PUBLIC_SHORT' },
-    );
+    return jsonSuccess({ status, database: 'connected', llm }, { cache: 'PUBLIC_SHORT' });
   } catch (error) {
     logger.error('Health check failed:', error);
     return jsonServiceUnavailable('Database connection failed');

--- a/tests/__tests__/lib/llm-health.test.ts
+++ b/tests/__tests__/lib/llm-health.test.ts
@@ -81,4 +81,14 @@ describe('chat routes do not dress a failure as success', () => {
     expect(source).toContain('getLLMHealth');
     expect(source).toMatch(/llm/);
   });
+
+  // Liveness must not fail on a dependency a restart cannot fix -- otherwise a
+  // stale API key gets a perfectly healthy process killed, and fails deploy
+  // gates on a problem no deploy caused. Readiness is where that belongs.
+  it('health separates liveness from readiness', () => {
+    const source = readFileSync(join(process.cwd(), 'app/api/health/route.ts'), 'utf-8');
+    expect(source).toContain('strict');
+    // the 503-on-LLM path must be gated behind strict, never unconditional
+    expect(source).toMatch(/if \(strict && llm\.status === 'down'\)/);
+  });
 });


### PR DESCRIPTION
#151 made `/api/health` return 503 whenever the LLM chain was down. That's right for **alerting** and wrong for **liveness**: restarting botsmann doesn't repair an expired Groq key, so the only effect of failing there is to get a healthy process killed — and to fail deploy gates on a problem no deploy caused. That's precisely the failure class that teaches people to bypass the gate.

## Two flavours

| Endpoint | Meaning | Behaviour |
|---|---|---|
| `GET /api/health` | **liveness** | 200 while the process serves and the database answers. Body still carries `status: healthy \| degraded \| down` and the full `llm` block, so the outage stays visible. |
| `GET /api/health?strict=1` | **readiness** | 503 once the chain is consistently failing. Point alerting here. |

`unknown` — nothing has exercised the chain since this process started — is not evidence of a problem, so it reports healthy rather than degraded.

## Was anything actually broken?

No. `selfhost-deploy.yml` curls the **homepage**, not this endpoint, so the deploy gate was never at risk. But the shape was wrong regardless, and the post-deploy guidance in CLAUDE.md *does* point a check at `/api/health`.

## Guard

The test now asserts the 503-on-LLM path stays behind `strict`, so it can't quietly become unconditional again.

## Verify

`format:check`, `lint`, `typecheck`, **269 tests**, `build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVwg8DKHQktxJuHeLM3xpG