### PR TITLE
chore: add a dependency watcher

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Dependency updates, weekly.
+#
+# Added 2026-08-29 after a fleet audit found 23 of 30 repos had no watcher at
+# all. The symptom looked like neglect and was not: aoz-housing had 100 commits
+# that month and was still on Next 14, because nothing ever opened the PR.
+# Drift here is the absence of a mechanism, not the absence of attention.
+#
+# Minor and patch are grouped into one PR so the auto-merge sweep spends one
+# cycle on them instead of five; majors stay separate because they deserve to
+# be read.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types: [minor, patch]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: "/"
+    directory: '/'
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
@@ -20,7 +20,7 @@ updates:
         update-types: [minor, patch]
 
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: '/'
     schedule:
       interval: weekly
     open-pull-requests-limit: 3


### PR DESCRIPTION
23 of 30 repos in the fleet had no dependency watcher at all.

The symptom looks like neglect and isn't. **aoz-housing had 100 commits in August** — features landing daily — and was still on Next 14, React 18 and Tailwind 3. Not because nobody touched it, but because **nothing ever opened the upgrade PR**. Version drift here is the absence of a mechanism, not the absence of attention.

Weekly. Minor and patch are grouped into one PR so the auto-merge sweep spends one cycle on them instead of five; majors stay separate because they deserve to be read. GitHub Actions versions are watched too — that is how a `uses:` reference goes stale unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvjGNAS9CMfEGNW26tUR4P
