### PR TITLE
fix(nav): the current page was coloured, never announced

### DIFF
--- a/components/navigation/NavItem.tsx
+++ b/components/navigation/NavItem.tsx
@@ -47,6 +47,9 @@ export function NavItem({ item, isActive, onNavigate }: NavItemProps) {
     return (
       <Link
         href={item.path}
+        // `isActive` already decides the colour; it never told assistive tech
+        // which page you were on. Zero aria-current existed in this codebase.
+        aria-current={isActive ? 'page' : undefined}
         className={`text-sm font-medium transition-colors ${
           isActive ? 'text-action' : 'text-gray-600'
         } hover:text-action`}


### PR DESCRIPTION
`isActive` already decided the link's colour and set no `aria-current` — the current page existed only for people who can see it. Zero occurrences of `aria-current` anywhere in this codebase.

The megamenu trigger is untouched: it's a disclosure button, not a link to a page, and `Popover.Button` already announces `aria-expanded`/`aria-haspopup` itself.

No visual change.

## Verification

`tsc --noEmit` shows 3 pre-existing errors (missing `vitest` types after the recent jest→vitest migration, confirmed unrelated by diffing with/without this change — identical count both ways). Lint clean.

Found by the fleet nav-contract audit, which flags a repo whose navigation computes an active state and never announces it anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XeELB8b3N4JrT2asYL9WvE