### PR TITLE
fix(nlp): route product-search query parsing through the multi-vendor LLM chain

### DIFF
--- a/lib/nlp.ts
+++ b/lib/nlp.ts
@@ -1,23 +1,23 @@
 import { NLPResult } from '@/types/products';
+import { generateWithBestProvider } from '@/lib/llm-client';
 
+/**
+ * Converts a one-word shopping query into structured search parameters.
+ *
+ * Routed through `generateWithBestProvider` (Ollama -> Groq -> OpenRouter),
+ * not a hardcoded OpenAI call: this used to `fetch` `api.openai.com` directly
+ * with a single model and no fallback, which meant it was dead code the
+ * moment `OPENAI_API_KEY` was unset (it always is in production) or OpenAI
+ * had an outage. Any failure -- provider unavailable, malformed JSON, no
+ * content -- degrades to a basic keyword search rather than surfacing an
+ * error, exactly as before.
+ */
 export async function processQuery(query: string): Promise<NLPResult> {
-  if (!process.env.OPENAI_API_KEY) {
-    throw new Error('OpenAI API key is not configured');
-  }
-
   try {
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
-        messages: [
-          {
-            role: 'system',
-            content: `Convert one-word shopping queries into structured product search parameters.
+    const { content } = await generateWithBestProvider([
+      {
+        role: 'system',
+        content: `Convert one-word shopping queries into structured product search parameters.
                    Return a JSON object with 'category' and 'attributes'.
                    Example: For "laptop", return:
                    {
@@ -28,26 +28,15 @@ export async function processQuery(query: string): Promise<NLPResult> {
                        "minStorage": "256GB"
                      }
                    }`,
-          },
-          {
-            role: 'user',
-            content: query,
-          },
-        ],
-        temperature: 0.7,
-        max_tokens: 150,
-      }),
-    });
-
-    if (!response.ok) {
-      throw new Error('Failed to process query with OpenAI');
-    }
-
-    const data = await response.json();
-    const content = data.choices[0]?.message?.content;
+      },
+      {
+        role: 'user',
+        content: query,
+      },
+    ]);
 
     if (!content) {
-      throw new Error('Invalid response from OpenAI');
+      throw new Error('Invalid response from LLM provider');
     }
 
     try {

--- a/tests/__tests__/lib/nlp.test.ts
+++ b/tests/__tests__/lib/nlp.test.ts
@@ -1,31 +1,29 @@
 import { processQuery } from '@/lib/nlp';
+import { generateWithBestProvider } from '@/lib/llm-client';
 import type { Mock } from 'vitest';
+
+vi.mock('@/lib/llm-client', () => ({
+  generateWithBestProvider: vi.fn(),
+}));
+
+const mockGenerateWithBestProvider = generateWithBestProvider as Mock;
 
 describe('NLP Processing', () => {
   beforeEach(() => {
-    // Mock OpenAI API response
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            choices: [
-              {
-                message: {
-                  content: JSON.stringify({
-                    category: 'electronics/computers',
-                    attributes: {
-                      type: 'laptop',
-                      minRam: '8GB',
-                      minStorage: '256GB',
-                    },
-                  }),
-                },
-              },
-            ],
-          }),
+    vi.clearAllMocks();
+    mockGenerateWithBestProvider.mockResolvedValue({
+      content: JSON.stringify({
+        category: 'electronics/computers',
+        attributes: {
+          type: 'laptop',
+          minRam: '8GB',
+          minStorage: '256GB',
+        },
       }),
-    ) as Mock;
+      provider: 'groq',
+      model: 'test-model',
+      providerInfo: 'groq (test-model)',
+    });
   });
 
   it('processes one-word query correctly', async () => {
@@ -40,8 +38,10 @@ describe('NLP Processing', () => {
     });
   });
 
-  it('handles API errors gracefully', async () => {
-    global.fetch = vi.fn(() => Promise.reject('API Error')) as Mock;
+  it('handles a fully unavailable LLM chain gracefully (no vendor bypass)', async () => {
+    mockGenerateWithBestProvider.mockRejectedValue(
+      new Error('No LLM provider available. Start Ollama or configure API keys.'),
+    );
     const result = await processQuery('laptop');
     expect(result).toEqual({
       category: 'general',
@@ -49,22 +49,36 @@ describe('NLP Processing', () => {
     });
   });
 
-  it('handles invalid API responses', async () => {
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            choices: [
-              {
-                message: {
-                  content: 'invalid json',
-                },
-              },
-            ],
-          }),
-      }),
-    ) as Mock;
+  it('handles provider errors gracefully', async () => {
+    mockGenerateWithBestProvider.mockRejectedValue(new Error('API Error'));
+    const result = await processQuery('laptop');
+    expect(result).toEqual({
+      category: 'general',
+      attributes: { query: 'laptop' },
+    });
+  });
+
+  it('handles invalid (non-JSON) provider responses', async () => {
+    mockGenerateWithBestProvider.mockResolvedValue({
+      content: 'invalid json',
+      provider: 'groq',
+      model: 'test-model',
+      providerInfo: 'groq (test-model)',
+    });
+    const result = await processQuery('laptop');
+    expect(result).toEqual({
+      category: 'general',
+      attributes: { query: 'laptop' },
+    });
+  });
+
+  it('handles an empty content response gracefully', async () => {
+    mockGenerateWithBestProvider.mockResolvedValue({
+      content: '',
+      provider: 'groq',
+      model: 'test-model',
+      providerInfo: 'groq (test-model)',
+    });
     const result = await processQuery('laptop');
     expect(result).toEqual({
       category: 'general',


### PR DESCRIPTION
## Bug

`lib/nlp.ts`'s `processQuery()` made a hardcoded direct `fetch('https://api.openai.com/v1/chat/completions', ...)` with a single model (`gpt-3.5-turbo`) and no fallback. `OPENAI_API_KEY` is not configured in production, so this path always threw before ever reaching the network — silently dead code on every call from `app/api/products/search/route.ts` since deployment, papered over only by the pre-existing basic-search fallback catch.

Found by this session's fleet-wide AI-reliability audit — the exact "single-vendor bypass, no fallback" shape that's been getting fixed across the fleet.

## Fix

Replace the hardcoded OpenAI call with `generateWithBestProvider` from `lib/llm-client.ts` — the same Ollama → Groq → OpenRouter chain every other AI call path in this repo already uses (e.g. `app/api/demo/chat/route.ts`).

- Preserves `processQuery`'s function signature and its existing graceful-degradation contract: malformed JSON or a fully unavailable provider chain still falls back to a basic keyword search (`{ category: 'general', attributes: { query } }`) instead of throwing to the route.
- No behavior change to callers — `app/api/products/search/route.ts` is untouched.

## Test plan

- [x] `tests/__tests__/lib/nlp.test.ts` rewritten to mock `generateWithBestProvider` instead of raw `fetch` (matches this repo's vitest convention), plus two new cases covering a fully-unavailable provider chain and an empty-content response
- [x] `npx vitest run` — 274 passed, 2 skipped (pre-existing skips, unrelated)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint . --max-warnings 0` — clean (scoped away from an unrelated stray `.claude/worktrees/nav-contract` leftover worktree that isn't part of the committed tree and won't exist in CI)
- [x] `npm run build` — clean
- [x] `grep -rn "api.openai.com\|api.anthropic.com" lib app` — no direct vendor fetches remain outside this file's explanatory comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)