### PR TITLE
fix(health): stop gating HTTP status on AI vendor health in strict mode

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,26 +1,22 @@
-import { type NextRequest } from 'next/server';
 import { supabase, isSupabaseConfigured } from '@/lib/supabase';
 import { jsonSuccess, jsonServiceUnavailable } from '@/lib/api';
 import { logger } from '@/lib/logger';
 import { getLLMHealth } from '@/lib/llm-health';
 
 /**
- * Health check, in two flavours.
+ * Health check (liveness): is this process serving and can it reach its
+ * database? Always 200 once the database answers, even when the LLM chain is
+ * down, because restarting the app does not fix an expired API key --
+ * failing liveness on it would just get a healthy process killed, and would
+ * fail deploy gates on a problem no deploy caused.
  *
- * Default (liveness): is this process serving and can it reach its database?
- * Answers 200 even when the LLM chain is down, because restarting the app does
- * not fix an expired API key -- failing liveness on it would just get a healthy
- * process killed, and would fail deploy gates on a problem no deploy caused.
- *
- * ?strict=1 (readiness): is the PRODUCT working? 503 once the LLM chain is
- * consistently failing. Point alerting here.
- *
- * Either way the body carries the real state. This endpoint used to report
- * only the database, so on 2026-08-28 it said "healthy" while every AI feature
- * on the site was failing on an invalid Groq key.
+ * The body still carries the real LLM state as an informational field, so
+ * alerting/dashboards can see it without the process being torn down for it.
+ * This endpoint used to report only the database, so on 2026-08-28 it said
+ * "healthy" while every AI feature on the site was failing on an invalid Groq
+ * key.
  */
-export async function GET(request: NextRequest) {
-  const strict = request.nextUrl.searchParams.get('strict') === '1';
+export async function GET() {
   const llm = getLLMHealth();
 
   try {
@@ -38,11 +34,6 @@ export async function GET(request: NextRequest) {
     // started. That is not evidence of a problem, so it is not degraded.
     const status =
       llm.status === 'down' ? 'down' : llm.status === 'degraded' ? 'degraded' : 'healthy';
-
-    if (strict && llm.status === 'down') {
-      logger.error('Health check (strict): LLM chain is down', { lastError: llm.lastError });
-      return jsonServiceUnavailable('AI provider unavailable');
-    }
 
     return jsonSuccess({ status, database: 'connected', llm }, { cache: 'PUBLIC_SHORT' });
   } catch (error) {

--- a/tests/__tests__/lib/llm-health.test.ts
+++ b/tests/__tests__/lib/llm-health.test.ts
@@ -82,13 +82,15 @@ describe('chat routes do not dress a failure as success', () => {
     expect(source).toMatch(/llm/);
   });
 
-  // Liveness must not fail on a dependency a restart cannot fix -- otherwise a
+  // Health must not fail on a dependency a restart cannot fix -- otherwise a
   // stale API key gets a perfectly healthy process killed, and fails deploy
-  // gates on a problem no deploy caused. Readiness is where that belongs.
-  it('health separates liveness from readiness', () => {
+  // gates on a problem no deploy caused. That holds for every caller, so
+  // there must be no query param that flips LLM status into an HTTP failure.
+  it('health never gates its HTTP status on LLM state', () => {
     const source = readFileSync(join(process.cwd(), 'app/api/health/route.ts'), 'utf-8');
-    expect(source).toContain('strict');
-    // the 503-on-LLM path must be gated behind strict, never unconditional
-    expect(source).toMatch(/if \(strict && llm\.status === 'down'\)/);
+    expect(source).not.toMatch(
+      /llm\.status === 'down'\)\s*{?\s*[\s\S]{0,80}jsonServiceUnavailable/,
+    );
+    expect(source).not.toContain('strict');
   });
 });


### PR DESCRIPTION
## Summary
- `/api/health?strict=1` returned HTTP 503 whenever the LLM chain was reported "down" -- a monitoring/orchestration system alerting or acting on that status code would treat it as a reason to restart the process, but a dead API key or exhausted free-tier budget can't be fixed by a restart. That's a pointless restart loop for a problem restarting can't solve.
- The default (no param) path already always answered 200 based on DB reachability; this removes the strict-mode carve-out that made behavior depend on a query param, so the endpoint's HTTP status now never depends on AI/LLM vendor state, full stop.
- LLM health remains in the response body as an informational field, unconditionally -- callers who want to know can still see it.
- The `strict` param existed only to drive this 503 gating, so it's removed entirely rather than left as dead branching.
- Updated the guard test in `tests/__tests__/lib/llm-health.test.ts` that asserted the old strict/readiness split to instead assert the route never gates HTTP status on LLM state and no longer references `strict`.

Note: this repo had a deliberate, previously-merged design (PR #153, 2026-08-28) splitting liveness (default, always 200) from readiness (`?strict=1`, 503 on LLM down, "point alerting here"). That design was reasoned and tested, not an oversight -- but per the standing fleet-wide rule (a health endpoint must never let AI/LLM vendor status drive its HTTP status, since nothing wired to it can act on that signal usefully), it's being closed the same way as the other two repos with this pattern. `strict=1` was confirmed dormant -- nothing in this repo's deploy/CI/monitoring config currently passes it.

## Test plan
- [x] `npm run typecheck` -- clean
- [x] `npm run check:selfhost` -- clean
- [x] `npm run test` -- 274 passed, 2 skipped (including the updated health guard test)
- [x] `npm run build` -- succeeds
- [x] `npx eslint` on the two changed files -- clean (full-repo `npm run lint` is currently broken by an unrelated stray git worktree from a concurrent session under `.claude/worktrees/`, reproduced on `main` with this change stashed -- not caused by this PR; CI runs a clean checkout and won't have that worktree)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)