### PR TITLE
refactor(deps): ai-kit comes from npm — @bitbaum/ai-kit ^0.6.2

### DIFF
--- a/lib/llm-client.ts
+++ b/lib/llm-client.ts
@@ -7,7 +7,7 @@
  * - Ollama (local)
  */
 
-import { freeChain, providerModels, usableChain, tryChain } from 'ai-kit';
+import { freeChain, providerModels, usableChain, tryChain } from '@bitbaum/ai-kit';
 import { API_CONFIG } from '@/lib/constants';
 import { getServerEnv, getClientEnv } from '@/lib/config/env';
 import { logger } from './logger';

--- a/lib/llm-health.ts
+++ b/lib/llm-health.ts
@@ -21,7 +21,7 @@
  * the ISO strings the health API has always returned.
  */
 
-import { createHealthTracker } from 'ai-kit';
+import { createHealthTracker } from '@bitbaum/ai-kit';
 
 /** Consecutive failures before we call the chain down rather than flaky. */
 const DOWN_AFTER_CONSECUTIVE_FAILURES = 3;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.980.0",
+        "@bitbaum/ai-kit": "^0.6.2",
         "@giscus/react": "^3.1.0",
         "@headlessui/react": "^2.2.0",
         "@supabase/ssr": "^0.8.0",
@@ -17,7 +18,6 @@
         "@tailwindcss/postcss": "^4.3.3",
         "@tailwindcss/typography": "^0.5.20",
         "@xenova/transformers": "^2.17.2",
-        "ai-kit": "github:bitbaum/ai-kit#v0.6.2",
         "date-fns": "^4.1.0",
         "gray-matter": "^4.0.3",
         "next": "^16.2.12",
@@ -1011,6 +1011,26 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bitbaum/ai-kit": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@bitbaum/ai-kit/-/ai-kit-0.6.2.tgz",
+      "integrity": "sha512-974ollQp2pugPpsUgdJY/i6r+/v3CEwa3XqmfSdi+vM7w8eMVWufSKQ3mu9QLoEm7b0Gq/mKgLKql3lSawmCfw==",
+      "license": "MIT",
+      "dependencies": {
+        "ai-forms": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "react": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -5254,25 +5274,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ai-kit": {
-      "version": "0.6.2",
-      "resolved": "git+ssh://git@github.com/bitbaum/ai-kit.git#ace11f14d817079ae2bf4cdc010b6daa9faacbec",
-      "license": "MIT",
-      "dependencies": {
-        "ai-forms": "^0.1.2"
-      },
-      "engines": {
-        "node": ">=20"
       },
       "peerDependencies": {
         "react": ">=18"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@tailwindcss/postcss": "^4.3.3",
     "@tailwindcss/typography": "^0.5.20",
     "@xenova/transformers": "^2.17.2",
-    "ai-kit": "github:bitbaum/ai-kit#v0.6.2",
+    "@bitbaum/ai-kit": "^0.6.2",
     "date-fns": "^4.1.0",
     "gray-matter": "^4.0.3",
     "next": "^16.2.12",

--- a/tests/__tests__/lib/free-fallback.test.ts
+++ b/tests/__tests__/lib/free-fallback.test.ts
@@ -23,7 +23,7 @@
  * routing and a per-call charge for identical weights, which is why an id one
  * token away from correct kept slipping through review.
  */
-import { freeChain, providerModels, modelCost } from 'ai-kit';
+import { freeChain, providerModels, modelCost } from '@bitbaum/ai-kit';
 
 const openRouter = freeChain('BOTSMANN')[1];
 

--- a/tests/__tests__/lib/llm-client.test.ts
+++ b/tests/__tests__/lib/llm-client.test.ts
@@ -17,7 +17,7 @@ vi.mock('@/lib/constants', () => ({
   },
 }));
 
-import { freeChain, providerModels } from 'ai-kit';
+import { freeChain, providerModels } from '@bitbaum/ai-kit';
 
 const GROQ_MODELS = providerModels(freeChain('BOTSMANN')[0]);
 const OPENROUTER_MODELS = providerModels(freeChain('BOTSMANN')[1]);


### PR DESCRIPTION
Wave 7 Phase A: swap the git-pinned `ai-kit` dependency to the published npm package.

- `package.json`: `"ai-kit": "github:bitbaum/ai-kit#v0.6.2"` → `"@bitbaum/ai-kit": "^0.6.2"`
- All `from 'ai-kit'` imports → `from '@bitbaum/ai-kit'`
- `npm install` re-resolved from the registry; `node_modules/@bitbaum/ai-kit` is 0.6.2 and no `ai-kit` git dep remains in the lockfile

The npm tarball is content-identical to the v0.6.2 git tag except the package name (npm's typosquat guard blocked unscoped `ai-kit`). This removes the git dependency whose lockfile entry recorded the writer's ssh transport + pnpm major instead of the dependency itself.

Verified locally: lint (0 errors), typecheck clean, full test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqKqMnHQHSmkGFfc5t7Rxn
